### PR TITLE
refine node resource controller

### DIFF
--- a/cmd/craned/app/manager.go
+++ b/cmd/craned/app/manager.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gocrane/crane/pkg/controller/noderesource"
+
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -252,4 +254,14 @@ func initializationControllers(ctx context.Context, mgr ctrl.Manager, opts *opti
 		log.Logger().Error(err, "unable to create controller", "controller", "RecommendationController")
 		os.Exit(1)
 	}
+	// NodeResourceController
+	if err := (&noderesource.NodeResourceReconciler{
+		Client:   mgr.GetClient(),
+		Log:      log.Logger().WithName("node-resource-controller"),
+		Recorder: mgr.GetEventRecorderFor("node-resource-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		log.Logger().Error(err, "unable to create controller", "controller", "NodeResourceController")
+		os.Exit(1)
+	}
+
 }

--- a/cmd/craned/app/manager.go
+++ b/cmd/craned/app/manager.go
@@ -101,8 +101,9 @@ func Run(ctx context.Context, opts *options.Options) error {
 		log.Logger().Error(err, "failed to add health check endpoint")
 		return err
 	}
-
-	initializationWebhooks(mgr, opts)
+	if opts.WebhookConfig.Enabled {
+		initializationWebhooks(mgr, opts)
+	}
 	initializationControllers(ctx, mgr, opts)
 	log.Logger().Info("Starting crane manager")
 

--- a/cmd/craned/app/options/options.go
+++ b/cmd/craned/app/options/options.go
@@ -3,12 +3,12 @@ package options
 import (
 	"time"
 
-	componentbaseconfig "k8s.io/component-base/config"
-
 	"github.com/spf13/pflag"
+	componentbaseconfig "k8s.io/component-base/config"
 
 	"github.com/gocrane/crane/pkg/prediction/config"
 	"github.com/gocrane/crane/pkg/providers"
+	"github.com/gocrane/crane/pkg/webhooks"
 )
 
 // Options hold the command-line options about crane manager
@@ -30,6 +30,9 @@ type Options struct {
 
 	// AlgorithmModelConfig
 	AlgorithmModelConfig config.AlgorithmModelConfig
+
+	// WebhookConfig
+	WebhookConfig webhooks.WebhookConfig
 }
 
 // NewOptions builds an empty options.
@@ -75,4 +78,5 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 
 	flags.DurationVar(&o.AlgorithmModelConfig.UpdateInterval, "model-update-interval", 12*time.Hour, "algorithm model update interval, now used for dsp model update interval")
 
+	flags.BoolVar(&o.WebhookConfig.Enabled, "webhook-enabled", true, "whether enable webhook or not, default to true")
 }

--- a/pkg/controller/noderesource/node_resource_controller.go
+++ b/pkg/controller/noderesource/node_resource_controller.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noderesource
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	predictionapi "github.com/gocrane/api/prediction/v1alpha1"
+)
+
+// NodeResourceReconciler reconciles a NodeResource object
+type NodeResourceReconciler struct {
+	client.Client
+	Log      logr.Logger
+	Recorder record.EventRecorder
+}
+
+//+kubebuilder:rbac:groups=node-resource.crane.io,resources=noderesources,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=node-resource.crane.io,resources=noderesources/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=node-resource.crane.io,resources=noderesources/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the NodeResource object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
+func (r *NodeResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.Log.Info("node resource reconcile", "node-resource", req.NamespacedName, req.Name)
+
+	nodePre := &predictionapi.NodePrediction{}
+	// 1.get NodePrediction result
+	err := r.Client.Get(ctx, req.NamespacedName, nodePre)
+	if err != nil {
+		r.Recorder.Event(nodePre, v1.EventTypeNormal, "FailedGetNodePrediction", err.Error())
+		r.Log.Error(err, "get node prediction error", "node-prediction", req.NamespacedName, req.Name)
+		return ctrl.Result{}, err
+	}
+
+	// TODO node timeserices api resp extract
+	// 2.get current node info
+	node := &v1.Node{}
+	nodeKey := client.ObjectKey{
+		Namespace: "",
+		Name:      "",
+	}
+	if err := r.Client.Get(ctx, nodeKey, node); err != nil {
+		r.Recorder.Event(node, v1.EventTypeNormal, "FailedGetNode", err.Error())
+		r.Log.Error(err, "get node error", "node", nodeKey.Namespace, nodeKey.Name)
+		return ctrl.Result{}, err
+	}
+	nodeCopy := node.DeepCopy()
+
+	// 3.build node status
+	nextPredictionResourceStatus := &nodePre.Status
+	//resources := make(map[v1.ResourceName]resource.Quantity)
+	for key, nextPossible := range nextPredictionResourceStatus.NextPossible {
+		for _, timeSeries := range nextPossible {
+			var resourceValue int64
+			if result, err := strconv.ParseInt(timeSeries.Value, 10, 64); err != nil {
+				r.Log.Error(err, "parse extend resource value error, resource value: %s", timeSeries.Value)
+				resourceValue = result
+			}
+			// cpu memory
+			if key == string(v1.ResourceCPU) {
+				nodeCopy.Status.Capacity["ext-resource.node.crane.io/cpu"] = *resource.NewQuantity(resourceValue, resource.DecimalSI)
+			}
+
+			if key == string(v1.ResourceMemory) {
+				nodeCopy.Status.Capacity["ext-resource.node.crane.io/memory"] = *resource.NewQuantity(resourceValue, resource.DecimalSI)
+			}
+		}
+	}
+
+	// 4.update Node status extend-resource info
+	// https://kubernetes.io/zh/docs/tasks/administer-cluster/extended-resource-node/
+	// TODO fix: strategic merge patch kubernetes
+	if err := r.Client.Status().Update(context.TODO(), nodeCopy); err != nil {
+		r.Recorder.Event(node, v1.EventTypeNormal, "FailedUpdateNodeExtendResource", err.Error())
+		r.Log.Error(err, "update Node status extend-resource error: %v", err)
+		return ctrl.Result{}, err
+	}
+	r.Recorder.Event(nodeCopy, v1.EventTypeNormal, "UpdateNode", "Update Node Extend Resource Success")
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NodeResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&predictionapi.NodePrediction{}).
+		Complete(r)
+}

--- a/pkg/controller/noderesource/node_resource_controller.go
+++ b/pkg/controller/noderesource/node_resource_controller.go
@@ -18,16 +18,26 @@ package noderesource
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	predictionapi "github.com/gocrane/api/prediction/v1alpha1"
+	"github.com/gocrane/crane/pkg/prediction/config"
+)
+
+const (
+	ExtResourcePrefix = "ext-resource.node.gocrane.io/%s"
+	MinDeltaRatio     = 0.1
+	CoolDownTime      = 5 * time.Minute
 )
 
 // NodeResourceReconciler reconciles a NodeResource object
@@ -41,77 +51,125 @@ type NodeResourceReconciler struct {
 //+kubebuilder:rbac:groups=node-resource.crane.io,resources=noderesources/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=node-resource.crane.io,resources=noderesources/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the NodeResource object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *NodeResourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("node resource reconcile", "node-resource", req.NamespacedName, req.Name)
 
-	nodePre := &predictionapi.NodePrediction{}
-	// 1.get NodePrediction result
-	err := r.Client.Get(ctx, req.NamespacedName, nodePre)
+	tsp := &predictionapi.TimeSeriesPrediction{}
+	// get TimeSeriesPrediction result
+	err := r.Client.Get(ctx, req.NamespacedName, tsp)
 	if err != nil {
-		r.Recorder.Event(nodePre, v1.EventTypeNormal, "FailedGetNodePrediction", err.Error())
-		r.Log.Error(err, "get node prediction error", "node-prediction", req.NamespacedName, req.Name)
+		r.Recorder.Event(tsp, v1.EventTypeNormal, "FailedGetTimeSeriesPrediction", err.Error())
+		r.Log.Error(err, "get TimeSeriesPrediction error", "TimeSeriesPrediction", req.NamespacedName, req.Name)
 		return ctrl.Result{}, err
 	}
 
-	// TODO node timeserices api resp extract
-	// 2.get current node info
-	node := &v1.Node{}
-	nodeKey := client.ObjectKey{
-		Namespace: "",
-		Name:      "",
+	// get current node info
+	target := tsp.Spec.TargetRef
+	if target.Kind != config.TargetKindNode {
+		return ctrl.Result{}, nil
 	}
-	if err := r.Client.Get(ctx, nodeKey, node); err != nil {
-		r.Recorder.Event(node, v1.EventTypeNormal, "FailedGetNode", err.Error())
-		r.Log.Error(err, "get node error", "node", nodeKey.Namespace, nodeKey.Name)
-		return ctrl.Result{}, err
-	}
-	nodeCopy := node.DeepCopy()
-
-	// 3.build node status
-	nextPredictionResourceStatus := &nodePre.Status
-	//resources := make(map[v1.ResourceName]resource.Quantity)
-	for key, nextPossible := range nextPredictionResourceStatus.NextPossible {
-		for _, timeSeries := range nextPossible {
-			var resourceValue int64
-			if result, err := strconv.ParseInt(timeSeries.Value, 10, 64); err != nil {
-				r.Log.Error(err, "parse extend resource value error, resource value: %s", timeSeries.Value)
-				resourceValue = result
-			}
-			// cpu memory
-			if key == string(v1.ResourceCPU) {
-				nodeCopy.Status.Capacity["ext-resource.node.crane.io/cpu"] = *resource.NewQuantity(resourceValue, resource.DecimalSI)
-			}
-
-			if key == string(v1.ResourceMemory) {
-				nodeCopy.Status.Capacity["ext-resource.node.crane.io/memory"] = *resource.NewQuantity(resourceValue, resource.DecimalSI)
-			}
+	node, err, retry := r.FindTargetNode(ctx, tsp)
+	if err != nil {
+		r.Recorder.Event(tsp, v1.EventTypeNormal, "FailedGetTargetNode", err.Error())
+		if !retry {
+			return ctrl.Result{}, nil
+		} else {
+			return ctrl.Result{}, err
 		}
 	}
 
-	// 4.update Node status extend-resource info
-	// https://kubernetes.io/zh/docs/tasks/administer-cluster/extended-resource-node/
-	// TODO fix: strategic merge patch kubernetes
-	if err := r.Client.Status().Update(context.TODO(), nodeCopy); err != nil {
-		r.Recorder.Event(node, v1.EventTypeNormal, "FailedUpdateNodeExtendResource", err.Error())
-		r.Log.Error(err, "update Node status extend-resource error: %v", err)
-		return ctrl.Result{}, err
+	nodeCopy := node.DeepCopy()
+	r.BuildNodeStatus(tsp, nodeCopy)
+	if !equality.Semantic.DeepEqual(&node.Status, &nodeCopy.Status) {
+		// update Node status extend-resource info
+		// TODO fix: strategic merge patch kubernetes
+		if err := r.Client.Status().Update(context.TODO(), nodeCopy); err != nil {
+			r.Recorder.Event(tsp, v1.EventTypeNormal, "FailedUpdateNodeExtendResource", err.Error())
+			r.Log.Error(err, "update Node status extend-resource error: %v", err)
+			return ctrl.Result{}, err
+		}
+		r.Recorder.Event(tsp, v1.EventTypeNormal, "UpdateNode", "Update Node Extend Resource Success")
 	}
-	r.Recorder.Event(nodeCopy, v1.EventTypeNormal, "UpdateNode", "Update Node Extend Resource Success")
 	return ctrl.Result{}, nil
+}
+
+func (r *NodeResourceReconciler) FindTargetNode(ctx context.Context, tsp *predictionapi.TimeSeriesPrediction) (*v1.Node, error, bool) {
+	address := tsp.Spec.TargetRef.Name
+	if address == "" {
+		return nil, fmt.Errorf("target is not specified"), false
+	}
+	nodeList := &v1.NodeList{}
+	if err := r.Client.List(ctx, nodeList); err != nil {
+		r.Log.Error(err, "list node error")
+		return nil, err, true
+	}
+	// the reason we use node ip instead of node name as the target name is
+	// some monitoring system does not persist node name
+	for _, n := range nodeList.Items {
+		for _, addr := range n.Status.Addresses {
+			if addr.Address == address {
+				r.Log.Info("Found target node", "nodeName", n.Name)
+				return &n, nil, false
+			}
+		}
+	}
+	return nil, fmt.Errorf("target [%s] not found", address), false
+}
+
+func (r *NodeResourceReconciler) BuildNodeStatus(tsp *predictionapi.TimeSeriesPrediction, node *v1.Node) {
+	idToResourceMap := map[string]*v1.ResourceName{}
+	for _, metrics := range tsp.Spec.PredictionMetrics {
+		if metrics.ResourceQuery == nil {
+			continue
+		}
+		idToResourceMap[metrics.ResourceIdentifier] = metrics.ResourceQuery
+	}
+	// build node status
+	nextPredictionResourceStatus := &tsp.Status
+	for _, metrics := range nextPredictionResourceStatus.PredictionMetrics {
+		resourceName, exists := idToResourceMap[metrics.ResourceIdentifier]
+		if !exists {
+			continue
+		}
+		for _, timeSeries := range metrics.Prediction {
+			var maxUsage, nextUsage int64
+			var nextUsageFloat float64
+			var err error
+			for _, sample := range timeSeries.Samples {
+				if nextUsageFloat, err = strconv.ParseFloat(sample.Value, 64); err != nil {
+					r.Log.Error(err, "parse extend resource value error, resource value: %s", sample.Value)
+					continue
+				}
+				nextUsage = int64(nextUsageFloat)
+				if maxUsage < nextUsage {
+					maxUsage = nextUsage
+				}
+			}
+			var nextRecommendation int64
+			switch *resourceName {
+			case v1.ResourceCPU:
+				nextRecommendation = node.Status.Allocatable.Cpu().Value() - maxUsage
+			case v1.ResourceMemory:
+				nextRecommendation = node.Status.Allocatable.Memory().Value() - maxUsage
+			default:
+				continue
+			}
+			extResourceName := fmt.Sprintf(ExtResourcePrefix, string(*resourceName))
+			resValue, exists := node.Status.Capacity[v1.ResourceName(extResourceName)]
+			if exists && float64(resValue.Value())/float64(nextRecommendation) <= 1+MinDeltaRatio {
+				continue
+			}
+			node.Status.Capacity[v1.ResourceName(extResourceName)] =
+				*resource.NewQuantity(nextRecommendation, resource.DecimalSI)
+			node.Status.Allocatable[v1.ResourceName(extResourceName)] =
+				*resource.NewQuantity(nextRecommendation, resource.DecimalSI)
+		}
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *NodeResourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&predictionapi.NodePrediction{}).
+		For(&predictionapi.TimeSeriesPrediction{}).
 		Complete(r)
 }

--- a/pkg/webhooks/config.go
+++ b/pkg/webhooks/config.go
@@ -1,0 +1,6 @@
+package webhooks
+
+// WebhookConfig represents the config of prometheus
+type WebhookConfig struct {
+	Enabled bool
+}

--- a/pkg/webhooks/webhook.go
+++ b/pkg/webhooks/webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package webhooks
 
 import (
 	"context"


### PR DESCRIPTION
add node resource controller, which behaves as the following:
1. watches all tsp
2. when tsp target ref is node, it list all nodes and find the target
3. it do nothing if tsp resource is not cpu or memory
4. it use capacity - predict result for the possible idle resource（max value of the prediction result)
5. when delta > 10%, it update node status with extended resource capacity