### PR TITLE
fix ext resource caculation bugs

### DIFF
--- a/pkg/prediction/config/config.go
+++ b/pkg/prediction/config/config.go
@@ -115,7 +115,7 @@ func (c *MetricContext) ResourceToPromQueryExpr(resourceName *corev1.ResourceNam
 	if strings.ToLower(c.TargetKind) == strings.ToLower(TargetKindNode) {
 		switch *resourceName {
 		case corev1.ResourceCPU:
-			return fmt.Sprintf(NodeCpuUsagePromQLFmtStr, c.Name, c.Name, "1m")
+			return fmt.Sprintf(NodeCpuUsagePromQLFmtStr, c.Name, c.Name, "5m")
 		case corev1.ResourceMemory:
 			return fmt.Sprintf(NodeMemUsagePromQLFmtStr, c.Name, c.Name)
 		}


### PR DESCRIPTION
fixes several things
1. continue when recommendation <0
2. cpu metrics in prometheus is in float, so we multiple it with 1000 before updating ext resource
3. memory metrics in prometheus is in Ki, so multiple the value with 1000 before minus by allocatable.
4. change cpu query irate step to 5min