### PR TITLE
correct crane agent log

### DIFF
--- a/deploy/crane-agent/daemonset.yaml
+++ b/deploy/crane-agent/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /crane-agent
-            - -v=4
+            - -v=2
             - --runtime-endpoint=unix:///rootvar/run/dockershim.sock
           name: crane-agent
           volumeMounts:

--- a/pkg/ensurance/analyzer/analyzer.go
+++ b/pkg/ensurance/analyzer/analyzer.go
@@ -172,7 +172,7 @@ func (s *AnormalyAnalyzer) Analyze(state map[string][]common.TimeSeries) {
 		}
 	}
 
-	klog.V(6).Infof("Analyze actionContexts: %v", actionContexts)
+	klog.V(4).Infof("Analyze actionContexts: %v", actionContexts)
 
 	//step 3 : merge
 	avoidanceAction := s.merge(state, avoidanceMaps, actionContexts)
@@ -200,7 +200,7 @@ func (s *AnormalyAnalyzer) trigger(series []common.TimeSeries, object ensurancea
 	for _, ts := range series {
 		triggered = s.evaluator.EvalWithMetric(object.MetricRule.Name, float64(object.MetricRule.Value.Value()), ts.Samples[0].Value)
 
-		klog.V(6).Infof("Anormaly detection result %v, Name: %s, Value: %.2f, %s/%s", triggered,
+		klog.V(4).Infof("Anormaly detection result %v, Name: %s, Value: %.2f, %s/%s", triggered,
 			object.MetricRule.Name,
 			ts.Samples[0].Value,
 			common.GetValueByName(ts.Labels, common.LabelNamePodNamespace),
@@ -230,7 +230,7 @@ func (s *AnormalyAnalyzer) analyze(key string, object ensuranceapi.ObjectiveEnsu
 	//step2: check if triggered for NodeQOSEnsurance
 	threshold := s.trigger(series, object)
 
-	klog.V(4).Infof("for NodeQOS %s, metrics reach the threshold: %v", key, threshold)
+	klog.V(2).Infof("for NodeQOS %s, metrics reach the threshold: %v", key, threshold)
 
 	//step3: check is triggered action or restored, set the detection
 	s.computeActionContext(threshold, key, object, &ac)
@@ -323,7 +323,7 @@ func (s *AnormalyAnalyzer) logEvent(ac ecache.ActionContext, now time.Time) {
 	//step1 print log if the detection state is changed
 	//step2 produce event
 	if ac.Triggered {
-		klog.V(4).Infof("LOG: %s triggered action %s", key, ac.ActionName)
+		klog.V(2).Infof("LOG: %s triggered action %s", key, ac.ActionName)
 
 		// record an event about the objective ensurance triggered
 		s.recorder.Event(nodeRef, v1.EventTypeWarning, "AvoidanceTriggered", fmt.Sprintf("%s triggered action %s", key, ac.ActionName))
@@ -332,7 +332,7 @@ func (s *AnormalyAnalyzer) logEvent(ac ecache.ActionContext, now time.Time) {
 
 	if ac.Restored {
 		if s.actionTriggered(ac) {
-			klog.V(4).Infof("LOG: %s restored action %s", key, ac.ActionName)
+			klog.V(2).Infof("LOG: %s restored action %s", key, ac.ActionName)
 			// record an event about the objective ensurance restored
 			s.recorder.Event(nodeRef, v1.EventTypeNormal, "RestoreTriggered", fmt.Sprintf("%s restored action %s", key, ac.ActionName))
 			s.actionEventStatus[key] = ecache.DetectionStatus{IsTriggered: false, LastTime: now}

--- a/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
+++ b/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
@@ -145,7 +145,7 @@ func (c *CadvisorCollector) Collect() (map[string][]common.TimeSeries, error) {
 				addSampleToStateMap(types.MetricNameContainerCpuQuota, composeSample(labels, float64(containerInfoV1.Spec.Cpu.Quota), now), stateMap)
 				addSampleToStateMap(types.MetricNameContainerCpuPeriod, composeSample(labels, float64(containerInfoV1.Spec.Cpu.Period), now), stateMap)
 
-				klog.V(10).Infof("Pod: %s, containerName: %s, key %s, scheduler run queue time %.2f", klog.KObj(pod), containerName, key, schedRunqueueTime)
+				klog.V(6).Infof("Pod: %s, containerName: %s, key %s, scheduler run queue time %.2f", klog.KObj(pod), containerName, key, schedRunqueueTime)
 			}
 			containerStates[key] = ContainerState{stat: v, timestamp: now}
 		}

--- a/pkg/ensurance/collector/collector.go
+++ b/pkg/ensurance/collector/collector.go
@@ -123,7 +123,7 @@ func (s *StateCollector) UpdateCollectors() {
 		}
 
 		if n.Spec.NodeQualityProbe.NodeLocalGet == nil {
-			klog.V(4).Infof("Probe type of NEP %s/%s is not node local, continue", n.Namespace, n.Name)
+			klog.V(2).Infof("Probe type of NEP %s/%s is not node local, continue", n.Namespace, n.Name)
 			continue
 		}
 

--- a/pkg/ensurance/collector/nodelocal/cpu.go
+++ b/pkg/ensurance/collector/nodelocal/cpu.go
@@ -64,7 +64,7 @@ func collectCPU(nodeState *nodeState) (map[string][]common.TimeSeries, error) {
 	usagePercent := calculateBusy(nodeState.latestCpuState.stat, currentCpuState.stat)
 	usageCore := usagePercent * float64(nodeState.cpuCoreNumbers) * 1000 / types.MaxPercentage
 
-	klog.V(6).Infof("CpuCollector collected,usagePercent %v, usageCore %v", usagePercent, usageCore)
+	klog.V(4).Infof("CpuCollector collected,usagePercent %v, usageCore %v", usagePercent, usageCore)
 
 	nodeState.latestCpuState = currentCpuState
 
@@ -86,7 +86,7 @@ func collectCPULoad(_ *nodeState) (map[string][]common.TimeSeries, error) {
 		return nil, fmt.Errorf("cpu load stat is nil")
 	}
 
-	klog.V(6).Infof("LoadCollector collected 1minLoad %v, 5minLoad %v, 15minLoad %v", stat.Load1, stat.Load5, stat.Load15)
+	klog.V(4).Infof("LoadCollector collected 1minLoad %v, 5minLoad %v, 15minLoad %v", stat.Load1, stat.Load5, stat.Load15)
 
 	var data = make(map[string][]common.TimeSeries, 3)
 	data[string(types.MetricNameCpuLoad1Min)] = []common.TimeSeries{{Samples: []common.Sample{{Value: stat.Load1, Timestamp: now.Unix()}}}}

--- a/pkg/ensurance/collector/nodelocal/memory.go
+++ b/pkg/ensurance/collector/nodelocal/memory.go
@@ -33,7 +33,7 @@ func collectMemory(_ *nodeState) (map[string][]common.TimeSeries, error) {
 	usage := stat.Total - stat.Available
 	usagePercent := float64(usage) / float64(stat.Total) * types.MaxPercentage
 
-	klog.V(6).Infof("MemoryCollector collected, total %d, Free %d, Available %d, usagePercent %.2f, usageCore %d",
+	klog.V(4).Infof("MemoryCollector collected, total %d, Free %d, Available %d, usagePercent %.2f, usageCore %d",
 		stat.Total, stat.Free, stat.Available, usagePercent, usage)
 
 	var data = make(map[string][]common.TimeSeries, 2)

--- a/pkg/ensurance/collector/nodelocal/nodelocal.go
+++ b/pkg/ensurance/collector/nodelocal/nodelocal.go
@@ -55,7 +55,7 @@ func (n *NodeLocal) GetType() types.CollectType {
 }
 
 func (n *NodeLocal) Collect() (map[string][]common.TimeSeries, error) {
-	klog.V(6).Infof("Node local collecting")
+	klog.V(4).Infof("Node local collecting")
 
 	var status = make(map[string][]common.TimeSeries)
 	for name, collect := range collectFuncMap {
@@ -70,7 +70,7 @@ func (n *NodeLocal) Collect() (map[string][]common.TimeSeries, error) {
 		}
 	}
 
-	klog.V(10).Info("Node local collecting, status: %v", status)
+	klog.V(6).Info("Node local collecting, status: %v", status)
 
 	return status, nil
 }

--- a/pkg/ensurance/executor/evict.go
+++ b/pkg/ensurance/executor/evict.go
@@ -40,7 +40,7 @@ func (e EvictPods) Find(key types.NamespacedName) int {
 }
 
 func (e *EvictExecutor) Avoid(ctx *ExecuteContext) error {
-	klog.V(6).Infof("EvictExecutor avoid, %v", *e)
+	klog.V(4).Infof("EvictExecutor avoid, %v", *e)
 
 	var bSucceed = true
 	var errPodKeys []string
@@ -68,7 +68,7 @@ func (e *EvictExecutor) Avoid(ctx *ExecuteContext) error {
 				return
 			}
 
-			klog.V(4).Infof("Pod %s is evicted", klog.KObj(pod))
+			klog.V(2).Infof("Pod %s is evicted", klog.KObj(pod))
 		}(e.EvictPods[i])
 	}
 

--- a/pkg/ensurance/executor/schedule.go
+++ b/pkg/ensurance/executor/schedule.go
@@ -29,7 +29,7 @@ type ClassAndPriority struct {
 }
 
 func (b *ScheduleExecutor) Avoid(ctx *ExecuteContext) error {
-	klog.V(6).Info("DisableScheduledExecutor avoid, %v", *b)
+	klog.V(4).Info("DisableScheduledExecutor avoid, %v", *b)
 
 	if b.DisableClassAndPriority == nil {
 		return nil
@@ -51,7 +51,7 @@ func (b *ScheduleExecutor) Avoid(ctx *ExecuteContext) error {
 }
 
 func (b *ScheduleExecutor) Restore(ctx *ExecuteContext) error {
-	klog.V(10).Info("DisableScheduledExecutor restore, %v", *b)
+	klog.V(6).Info("DisableScheduledExecutor restore, %v", *b)
 
 	if b.RestoreClassAndPriority == nil {
 		return nil
@@ -111,7 +111,7 @@ func GetMaxQOSPriority(podLister corelisters.PodLister, podTypes []types.Namespa
 
 	for _, podNamespace := range podTypes {
 		if pod, err := podLister.Pods(podNamespace.Namespace).Get(podNamespace.Name); err != nil {
-			klog.V(6).Infof("Warning: getMaxQOSPriority get pod %s not found", podNamespace.String())
+			klog.V(4).Infof("Warning: getMaxQOSPriority get pod %s not found", podNamespace.String())
 			continue
 		} else {
 			var priority = ClassAndPriority{PodQOSClass: pod.Status.QOSClass, PriorityClassValue: utils.GetInt32withDefault(pod.Spec.Priority, 0) - 1}

--- a/pkg/ensurance/executor/throttle.go
+++ b/pkg/ensurance/executor/throttle.go
@@ -106,7 +106,7 @@ func (t *ThrottleExecutor) Avoid(ctx *ExecuteContext) error {
 				continue
 			}
 
-			klog.V(4).Infof("ThrottleExecutor1 avoid container %s/%s", klog.KObj(pod), v.ContainerName)
+			klog.V(2).Infof("ThrottleExecutor1 avoid container %s/%s", klog.KObj(pod), v.ContainerName)
 
 			containerCPUQuota, err := GetUsageById(throttlePod.ContainerCPUQuotas, v.ContainerId)
 			if err != nil {
@@ -148,7 +148,7 @@ func (t *ThrottleExecutor) Avoid(ctx *ExecuteContext) error {
 				}
 			}
 
-			klog.V(6).Infof("Prior update container resources containerCPUQuotaNew %.2f, containerCPUQuota.Value %.2f,containerCPUPeriod %.2f",
+			klog.V(4).Infof("Prior update container resources containerCPUQuotaNew %.2f, containerCPUQuota.Value %.2f,containerCPUPeriod %.2f",
 				containerCPUQuotaNew, containerCPUQuota.Value, containerCPUPeriod.Value)
 
 			if !utils.AlmostEqual(containerCPUQuotaNew*containerCPUPeriod.Value, containerCPUQuota.Value) {
@@ -158,7 +158,7 @@ func (t *ThrottleExecutor) Avoid(ctx *ExecuteContext) error {
 					bSucceed = false
 					continue
 				} else {
-					klog.V(4).Infof("ThrottleExecutor avoid pod %s, container %s, set cpu quota %.2f.",
+					klog.V(2).Infof("ThrottleExecutor avoid pod %s, container %s, set cpu quota %.2f.",
 						klog.KObj(pod), v.ContainerName, containerCPUQuotaNew)
 				}
 			}
@@ -192,7 +192,7 @@ func (t *ThrottleExecutor) Restore(ctx *ExecuteContext) error {
 				continue
 			}
 
-			klog.V(6).Infof("ThrottleExecutor1 restore container %s/%s", klog.KObj(pod), v.ContainerName)
+			klog.V(4).Infof("ThrottleExecutor1 restore container %s/%s", klog.KObj(pod), v.ContainerName)
 
 			containerCPUQuota, err := GetUsageById(throttlePod.ContainerCPUQuotas, v.ContainerId)
 			if err != nil {
@@ -232,7 +232,7 @@ func (t *ThrottleExecutor) Restore(ctx *ExecuteContext) error {
 				}
 			}
 
-			klog.V(6).Infof("Prior update container resources containerCPUQuotaNew %.2f,containerCPUQuota %.2f,containerCPUPeriod %.2f",
+			klog.V(4).Infof("Prior update container resources containerCPUQuotaNew %.2f,containerCPUQuota %.2f,containerCPUPeriod %.2f",
 				klog.KObj(pod), containerCPUQuotaNew, containerCPUQuota.Value, containerCPUPeriod.Value)
 
 			if !utils.AlmostEqual(containerCPUQuotaNew*containerCPUPeriod.Value, containerCPUQuota.Value) {

--- a/pkg/ensurance/grpc/connection.go
+++ b/pkg/ensurance/grpc/connection.go
@@ -23,7 +23,7 @@ func InitGrpcConnection(endPoints []string) (*grpc.ClientConn, error) {
 
 	var conn *grpc.ClientConn
 	for idx, v := range endPoints {
-		klog.V(4).Infof("Connect using endpoint '%s' with '%s' timeout", v, defaultTimeout)
+		klog.V(2).Infof("Connect using endpoint '%s' with '%s' timeout", v, defaultTimeout)
 		addr, dialer, err := utils.GetAddressAndDialer(v)
 		if err != nil {
 			if idx == (len - 1) {

--- a/pkg/ensurance/runtime/container.go
+++ b/pkg/ensurance/runtime/container.go
@@ -80,14 +80,14 @@ func UpdateContainerResources(client pb.RuntimeServiceClient, containerId string
 		},
 	}
 
-	klog.V(6).Infof("UpdateContainerResourcesRequest: %v", request)
+	klog.V(4).Infof("UpdateContainerResourcesRequest: %v", request)
 
 	r, err := client.UpdateContainerResources(context.Background(), request)
 	if err != nil {
 		return err
 	}
 
-	klog.V(10).Infof("UpdateContainerResourcesResponse: %v", r)
+	klog.V(6).Infof("UpdateContainerResourcesResponse: %v", r)
 	return nil
 }
 
@@ -103,14 +103,14 @@ func RemoveContainer(client pb.RuntimeServiceClient, ContainerId string) error {
 		ContainerId: ContainerId,
 	}
 
-	klog.V(6).Infof("RemoveContainerRequest: %v", request)
+	klog.V(4).Infof("RemoveContainerRequest: %v", request)
 
 	r, err := client.RemoveContainer(context.Background(), request)
 	if err != nil {
 		return err
 	}
 
-	klog.V(10).Infof("RemoveContainerResponse: %v", r)
+	klog.V(6).Infof("RemoveContainerResponse: %v", r)
 	return nil
 }
 
@@ -166,14 +166,14 @@ func ListContainers(runtimeClient pb.RuntimeServiceClient, opts ListOptions) ([]
 		Filter: filter,
 	}
 
-	klog.V(6).Info("ListContainerRequest: %v", request)
+	klog.V(4).Info("ListContainerRequest: %v", request)
 
 	r, err := runtimeClient.ListContainers(context.Background(), request)
 	if err != nil {
 		return []*pb.Container{}, err
 	}
 
-	klog.V(10).Info("ListContainerResponse: %v", r)
+	klog.V(6).Info("ListContainerResponse: %v", r)
 
 	r.Containers = filterContainersList(r.GetContainers(), opts)
 


### PR DESCRIPTION
Cadvisor uses a lot of 4 level log, so there are many disturbing cadvisor log in current log level.
<img width="1521" alt="wecom-temp-cf2dcd4935c8fc6a6978cc9f12442dec" src="https://user-images.githubusercontent.com/15925403/156488306-bc367174-6183-4261-ac08-724defd25f43.png">

Change crane agent's important log to level 2 and use level 2 as default.And use level 4 and 6 for test.
 