### PR TITLE
make cadvisor a member variable in collector

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -68,7 +68,7 @@ func NewAgent(ctx context.Context,
 	}
 
 	if podResource := utilfeature.DefaultFeatureGate.Enabled(features.CranePodResource); podResource {
-		podResourceManager :=  resource.NewPodResourceManager(kubeClient, nodeName, podInformer, runtimeEndpoint, stateCollector.PodResourceChann, stateCollector.GetCollectors())
+		podResourceManager :=  resource.NewPodResourceManager(kubeClient, nodeName, podInformer, runtimeEndpoint, stateCollector.PodResourceChann, stateCollector.GetCadvisorManager())
 		managers = append(managers, podResourceManager)
 	}
 

--- a/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
+++ b/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
@@ -45,8 +45,7 @@ type CadvisorCollector struct {
 	latestContainersStates map[string]ContainerState
 }
 
-func NewCadvisor(podLister corelisters.PodLister) *CadvisorCollector {
-
+func NewCadvisorManager() cmanager.Manager {
 	var includedMetrics = cadvisorcontainer.MetricSet{
 		cadvisorcontainer.CpuUsageMetrics:         struct{}{},
 		cadvisorcontainer.ProcessSchedulerMetrics: struct{}{},
@@ -64,16 +63,18 @@ func NewCadvisor(podLister corelisters.PodLister) *CadvisorCollector {
 		return nil
 	}
 
+	if err := m.Start(); err != nil {
+		klog.Errorf("Failed to start cadvisor manager: %v", err)
+		return nil
+	}
+	return m
+}
+
+func NewCadvisor(podLister corelisters.PodLister, m cmanager.Manager) *CadvisorCollector {
 	c := CadvisorCollector{
 		Manager:   m,
 		podLister: podLister,
 	}
-
-	if err := c.Manager.Start(); err != nil {
-		klog.Errorf("Failed to start cadvisor manager: %v", err)
-		return nil
-	}
-
 	return &c
 }
 

--- a/pkg/ensurance/collector/collector.go
+++ b/pkg/ensurance/collector/collector.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	cmanager "github.com/google/cadvisor/manager"
 	"k8s.io/apimachinery/pkg/labels"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -29,6 +30,7 @@ type StateCollector struct {
 	collectInterval   time.Duration
 	ifaces            []string
 	collectors        *sync.Map
+	cadvisorManager   cmanager.Manager
 	AnalyzerChann     chan map[string][]common.TimeSeries
 	NodeResourceChann chan map[string][]common.TimeSeries
 	PodResourceChann  chan map[string][]common.TimeSeries
@@ -39,6 +41,7 @@ func NewStateCollector(nodeName string, nepLister ensuranceListers.NodeQOSEnsura
 	analyzerChann := make(chan map[string][]common.TimeSeries)
 	nodeResourceChann := make(chan map[string][]common.TimeSeries)
 	podResourceChann := make(chan map[string][]common.TimeSeries)
+	c := cadvisor.NewCadvisorManager()
 	return &StateCollector{
 		nodeName:          nodeName,
 		nepLister:         nepLister,
@@ -51,6 +54,7 @@ func NewStateCollector(nodeName string, nepLister ensuranceListers.NodeQOSEnsura
 		NodeResourceChann: nodeResourceChann,
 		PodResourceChann:  podResourceChann,
 		collectors:        &sync.Map{},
+		cadvisorManager:   c,
 	}
 }
 
@@ -171,10 +175,8 @@ func (s *StateCollector) UpdateCollectors() {
 		}
 
 		if _, exists := s.collectors.Load(types.CadvisorCollectorType); !exists {
-			c := cadvisor.NewCadvisor(s.podLister)
-			if c != nil {
-				s.collectors.Store(types.CadvisorCollectorType, c)
-			}
+			cadvisorCollector := cadvisor.NewCadvisor(s.podLister, s.GetCadvisorManager())
+			s.collectors.Store(types.CadvisorCollectorType, cadvisorCollector)
 		}
 		break
 	}
@@ -198,6 +200,10 @@ func (s *StateCollector) UpdateCollectors() {
 
 func (s *StateCollector) GetCollectors() *sync.Map {
 	return s.collectors
+}
+
+func (s *StateCollector) GetCadvisorManager() cmanager.Manager {
+	return s.cadvisorManager
 }
 
 func (s *StateCollector) StopCollectors() {


### PR DESCRIPTION
#### What type of PR is this?
feature

#### What this PR does / why we need it:
We found that many modules need to use cadvisor in collector, such as pod resource manager, cpu set manager, while only when nep has nodelocal configure cadvisor can exist.

So make cadvisor a  member variable in collector and be configuration independent.
