### PR TITLE
make cadvisor a member variable in collector; fix make test cadvisor error

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -63,7 +63,7 @@ func NewAgent(ctx context.Context,
 	avoidanceManager := executor.NewActionExecutor(kubeClient, nodeName, podInformer, nodeInformer, noticeCh, runtimeEndpoint)
 	managers = appendManagerIfNotNil(managers, avoidanceManager)
 	if craneCpuSetManager := utilfeature.DefaultFeatureGate.Enabled(features.CraneCpuSetManager); craneCpuSetManager {
-		cpuManager := cm.NewAdvancedCpuManager(podInformer, runtimeEndpoint, stateCollector.GetCollectors())
+		cpuManager := cm.NewAdvancedCpuManager(podInformer, runtimeEndpoint, stateCollector.GetCadvisorManager())
 		managers = appendManagerIfNotNil(managers, cpuManager)
 	}
 
@@ -73,7 +73,7 @@ func NewAgent(ctx context.Context,
 	}
 
 	if podResource := utilfeature.DefaultFeatureGate.Enabled(features.CranePodResource); podResource {
-		podResourceManager := resource.NewPodResourceManager(kubeClient, nodeName, podInformer, runtimeEndpoint, stateCollector.PodResourceChann, stateCollector.GetCollectors())
+		podResourceManager := resource.NewPodResourceManager(kubeClient, nodeName, podInformer, runtimeEndpoint, stateCollector.PodResourceChann, stateCollector.GetCadvisorManager())
 		managers = appendManagerIfNotNil(managers, podResourceManager)
 	}
 

--- a/pkg/ensurance/collector/cadvisor/cadvisor_unsupported.go
+++ b/pkg/ensurance/collector/cadvisor/cadvisor_unsupported.go
@@ -4,27 +4,50 @@
 package cadvisor
 
 import (
+	info "github.com/google/cadvisor/info/v1"
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+	corelisters "k8s.io/client-go/listers/core/v1"
+
 	"github.com/gocrane/crane/pkg/common"
 	"github.com/gocrane/crane/pkg/ensurance/collector/types"
-	corelisters "k8s.io/client-go/listers/core/v1"
 )
 
-type CadvisorCollector struct {
+type CadvisorCollectorUnsupport struct {
+	Manager Manager
 }
 
-func NewCadvisor(_ corelisters.PodLister) *CadvisorCollector {
-	return &CadvisorCollector{}
+type CadvisorManagerUnsupport struct {
 }
 
-func (c *CadvisorCollector) Stop() error {
+func NewCadvisorManager() Manager {
+	return &CadvisorManagerUnsupport{}
+}
+
+func NewCadvisorCollector(_ corelisters.PodLister, manager Manager) *CadvisorCollectorUnsupport {
+	return &CadvisorCollectorUnsupport{}
+}
+
+func (c *CadvisorCollectorUnsupport) Stop() error {
 	return nil
 }
 
-func (c *CadvisorCollector) GetType() types.CollectType {
+func (c *CadvisorCollectorUnsupport) GetType() types.CollectType {
 	return types.CadvisorCollectorType
 }
 
-func (c *CadvisorCollector) Collect() (map[string][]common.TimeSeries, error) {
+func (c *CadvisorCollectorUnsupport) Collect() (map[string][]common.TimeSeries, error) {
+	return nil, nil
+}
+
+func (m *CadvisorManagerUnsupport) GetContainerInfoV2(containerName string, options cadvisorapiv2.RequestOptions) (map[string]cadvisorapiv2.ContainerInfo, error) {
+	return nil, nil
+}
+
+func (m *CadvisorManagerUnsupport) GetContainerInfo(containerName string, query *info.ContainerInfoRequest) (*info.ContainerInfo, error) {
+	return nil, nil
+}
+
+func (m *CadvisorManagerUnsupport) GetMachineInfo() (*info.MachineInfo, error) {
 	return nil, nil
 }
 

--- a/pkg/ensurance/collector/cadvisor/types.go
+++ b/pkg/ensurance/collector/cadvisor/types.go
@@ -1,0 +1,12 @@
+package cadvisor
+
+import (
+	info "github.com/google/cadvisor/info/v1"
+	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
+)
+
+type Manager interface {
+	GetContainerInfoV2(containerName string, options cadvisorapiv2.RequestOptions) (map[string]cadvisorapiv2.ContainerInfo, error)
+	GetContainerInfo(containerName string, query *info.ContainerInfoRequest) (*info.ContainerInfo, error)
+	GetMachineInfo() (*info.MachineInfo, error)
+}

--- a/pkg/resource/pod_resource_manger.go
+++ b/pkg/resource/pod_resource_manger.go
@@ -3,7 +3,6 @@ package resource
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	info "github.com/google/cadvisor/info/v1"
@@ -19,7 +18,6 @@ import (
 
 	"github.com/gocrane/crane/pkg/common"
 	"github.com/gocrane/crane/pkg/ensurance/collector/cadvisor"
-	"github.com/gocrane/crane/pkg/ensurance/collector/types"
 	stypes "github.com/gocrane/crane/pkg/ensurance/collector/types"
 	"github.com/gocrane/crane/pkg/ensurance/executor"
 	cgrpc "github.com/gocrane/crane/pkg/ensurance/grpc"
@@ -45,11 +43,11 @@ type PodResourceManager struct {
 	// Updated when get new data from stateChann, used to determine whether state has expired
 	lastStateTime time.Time
 
-	collectors *sync.Map
+	cadvisor.Manager
 }
 
 func NewPodResourceManager(client clientset.Interface, nodeName string, podInformer coreinformers.PodInformer,
-	runtimeEndpoint string, stateChann chan map[string][]common.TimeSeries, collectors *sync.Map) *PodResourceManager {
+	runtimeEndpoint string, stateChann chan map[string][]common.TimeSeries, cadvisorManager cadvisor.Manager) *PodResourceManager {
 	runtimeClient, runtimeConn, err := cruntime.GetRuntimeClient(runtimeEndpoint, true)
 	if err != nil {
 		klog.Errorf("GetRuntimeClient failed %s", err.Error())
@@ -64,7 +62,7 @@ func NewPodResourceManager(client clientset.Interface, nodeName string, podInfor
 		runtimeClient: runtimeClient,
 		runtimeConn:   runtimeConn,
 		stateChann:    stateChann,
-		collectors:    collectors,
+		Manager:       cadvisorManager,
 	}
 	podInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		// Focused on pod belonged to this node
@@ -188,16 +186,12 @@ func (o *PodResourceManager) updatePodExtResToCgroup(pod *v1.Pod) {
 	metrics.UpdateDurationFromStart(string(known.ModulePodResourceManager), metrics.StepUpdatePodResource, start)
 }
 
-// Get cpu period from local if cadvisor collector exists and state is not expired;
+// Get cpu period from local state is not expired;
 // Otherwise, get value from CRI
 func (o *PodResourceManager) getCPUPeriod(pod *v1.Pod, containerId string) float64 {
-	value, exists := o.collectors.Load(types.CadvisorCollectorType)
-	if !exists {
-		return 0.0
-	}
 	now := time.Now()
 
-	if exists && o.state != nil && !now.After(o.lastStateTime.Add(StateExpiration)) {
+	if o.state != nil && !now.After(o.lastStateTime.Add(StateExpiration)) {
 		_, containerCPUPeriods := executor.GetPodUsage(string(stypes.MetricNameContainerCpuPeriod), o.state, pod)
 		for _, period := range containerCPUPeriods {
 			if period.ContainerId == containerId {
@@ -207,9 +201,8 @@ func (o *PodResourceManager) getCPUPeriod(pod *v1.Pod, containerId string) float
 	}
 
 	// Use CRI to get cpu period directly
-	c := value.(*cadvisor.CadvisorCollector)
 	var query = info.ContainerInfoRequest{}
-	containerInfoV1, err := c.Manager.GetContainerInfo(containerId, &query)
+	containerInfoV1, err := o.Manager.GetContainerInfo(containerId, &query)
 	if err != nil {
 		metrics.PodResourceUpdateErrorCounterInc(metrics.SubComponentPodResource, metrics.StepGetPeriod)
 		klog.Errorf("ContainerInfoRequest failed for container %s: %v ", containerId, err)


### PR DESCRIPTION
1. Make cadvisor a member variable in collector:
We found that many modules need to use cadvisor in collector, such as pod resource manager, cpu set manager, while only when nep has nodelocal configure cadvisor can exist.
So make cadvisor a member variable in collector and be configuration independent.

2. Fix make test error.