### PR TITLE
refine the cron ehpa to single metric for multiple crons

### DIFF
--- a/deploy/metric-adapter/rbac.yaml
+++ b/deploy/metric-adapter/rbac.yaml
@@ -3,40 +3,9 @@ kind: ClusterRole
 metadata:
   name: metric-adapter
 rules:
-  - apiGroups:
-      - "prediction.crane.io"
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - "autoscaling.crane.io"
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - 'configmaps'
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - "custom.metrics.k8s.io"
-    resources:
-      - '*'
-    verbs:
-      - '*'
+  - apiGroups: [ '*' ]
+    resources: [ '*' ]
+    verbs: [ "*" ]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/utils/scale.go
+++ b/pkg/utils/scale.go
@@ -32,14 +32,16 @@ func GetScale(ctx context.Context, restMapper meta.RESTMapper, scaleClient scale
 		return nil, nil, err
 	}
 
+	var errs []error
 	for _, mapping := range mappings {
 		scale, err := scaleClient.Scales(namespace).Get(ctx, mapping.Resource.GroupResource(), ref.Name, metav1.GetOptions{})
 		if err == nil {
 			return scale, mapping, nil
 		}
+		errs = append(errs, err)
 	}
 
-	return nil, nil, fmt.Errorf("unrecognized resource")
+	return nil, nil, fmt.Errorf("unrecognized resource: %+v", errs)
 }
 
 func GetPodsFromScale(kubeClient client.Client, scale *autoscalingapiv1.Scale) ([]v1.Pod, error) {

--- a/pkg/utils/target/fetcher.go
+++ b/pkg/utils/target/fetcher.go
@@ -138,7 +138,7 @@ func (f *targetSelectorFetcher) getLabelSelectorFromScale(groupKind schema.Group
 		return nil, err
 	}
 
-	var lastError error
+	var errs []error
 	for _, mapping := range mappings {
 		groupResource := mapping.Resource.GroupResource()
 		scale, err := f.ScaleClient.Scales(namespace).Get(context.TODO(), groupResource, name, metav1.GetOptions{})
@@ -152,7 +152,7 @@ func (f *targetSelectorFetcher) getLabelSelectorFromScale(groupKind schema.Group
 			}
 			return selector, nil
 		}
-		lastError = err
+		errs = append(errs, err)
 	}
-	return nil, lastError
+	return nil, fmt.Errorf("%+v", errs)
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Feature

#### What this PR does / why we need it:
Now, cron has some flaws if only specified one cron, then if the time is not in cron start and end, the metric will be default 1. it is unexpected for users.

Mapping many crons in one ehpa to only one metric, put many cron compare logic in metric-adapter to solve this problem.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #226 

#### Special notes for your reviewer:

