### PR TITLE
refine querybuilder factory to register way, to avoid switch case mod…

### DIFF
--- a/pkg/metricnaming/naming.go
+++ b/pkg/metricnaming/naming.go
@@ -3,8 +3,6 @@ package metricnaming
 import (
 	"github.com/gocrane/crane/pkg/metricquery"
 	"github.com/gocrane/crane/pkg/querybuilder"
-	msbuilder "github.com/gocrane/crane/pkg/querybuilder-providers/metricserver"
-	prombuilder "github.com/gocrane/crane/pkg/querybuilder-providers/prometheus"
 )
 
 // MetricNamer is an interface. it is the bridge between predictor and different data sources and other component.
@@ -38,13 +36,8 @@ type queryBuilderFactory struct {
 }
 
 func (q queryBuilderFactory) Builder(source metricquery.MetricSource) querybuilder.Builder {
-	switch source {
-	case metricquery.MetricServerMetricSource:
-		return msbuilder.NewMetricServerQueryBuilder(q.metric)
-	case metricquery.PrometheusMetricSource:
-		return prombuilder.NewPromQueryBuilder(q.metric)
-	}
-	return prombuilder.NewPromQueryBuilder(q.metric)
+	initFunc := querybuilder.GetBuilderFactory(source)
+	return initFunc(q.metric)
 }
 
 func NewQueryBuilder(metric *metricquery.Metric) querybuilder.QueryBuilder {

--- a/pkg/querybuilder-providers/metricserver/builder.go
+++ b/pkg/querybuilder-providers/metricserver/builder.go
@@ -27,3 +27,7 @@ func metricServerQuery(query *metricquery.MetricServerQuery) *metricquery.Query 
 		MetricServer: query,
 	}
 }
+
+func init() {
+	querybuilder.RegisterBuilderFactory(metricquery.MetricServerMetricSource, NewMetricServerQueryBuilder)
+}

--- a/pkg/querybuilder-providers/prometheus/builder.go
+++ b/pkg/querybuilder-providers/prometheus/builder.go
@@ -154,3 +154,7 @@ func promQuery(prom *metricquery.PrometheusQuery) *metricquery.Query {
 		Prometheus: prom,
 	}
 }
+
+func init() {
+	querybuilder.RegisterBuilderFactory(metricquery.PrometheusMetricSource, NewPromQueryBuilder)
+}

--- a/pkg/querybuilder/query.go
+++ b/pkg/querybuilder/query.go
@@ -1,6 +1,8 @@
 package querybuilder
 
 import (
+	"sync"
+
 	"github.com/gocrane/crane/pkg/metricquery"
 )
 
@@ -12,4 +14,23 @@ type Builder interface {
 // QueryBuilder is an Builder factory to make Builders
 type QueryBuilder interface {
 	Builder(source metricquery.MetricSource) Builder
+}
+
+var (
+	factoryLock    sync.Mutex
+	builderFactory = make(map[metricquery.MetricSource]BuilderFactoryFunc)
+)
+
+type BuilderFactoryFunc func(metric *metricquery.Metric) Builder
+
+func RegisterBuilderFactory(metricSource metricquery.MetricSource, initFunc BuilderFactoryFunc) {
+	factoryLock.Lock()
+	defer factoryLock.Unlock()
+	builderFactory[metricSource] = initFunc
+}
+
+func GetBuilderFactory(metricSource metricquery.MetricSource) BuilderFactoryFunc {
+	factoryLock.Lock()
+	defer factoryLock.Unlock()
+	return builderFactory[metricSource]
 }


### PR DESCRIPTION
…e. each implementer only register by init way

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
refine querybuilder factory to register way

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #238 

#### Special notes for your reviewer:

