### PR TITLE
support init mode for metric model

### DIFF
--- a/pkg/controller/evpa/effective_vpa_controller.go
+++ b/pkg/controller/evpa/effective_vpa_controller.go
@@ -158,6 +158,9 @@ func recordMetric(evpa *autoscalingapi.EffectiveVerticalPodAutoscaler, status *a
 		"resourceName": fmt.Sprintf("%s/%s", evpa.Namespace, evpa.Spec.TargetRef.Name),
 	}
 
+	if status.Recommendation == nil {
+		return
+	}
 	for _, container := range status.Recommendation.ContainerRecommendations {
 		resourceRequirement, found := utils.GetResourceByPodTemplate(podTemplate, container.ContainerName)
 		if !found {

--- a/pkg/metricnaming/naming.go
+++ b/pkg/metricnaming/naming.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gocrane/crane/pkg/querybuilder"
 )
 
-// MetricNamer is an interface. it is the bridge between predictor and different data sources and other component.
+// MetricNamer is an interface. it is the bridge between predictor and different data sources and other component such as caller.
 type MetricNamer interface {
 	// Used for datasource provider, data source provider call QueryBuilder
 	QueryBuilder() querybuilder.QueryBuilder
@@ -13,10 +13,20 @@ type MetricNamer interface {
 	BuildUniqueKey() string
 
 	Validate() error
+
+	// Means the caller of this MetricNamer, different caller maybe use the same metric
+	Caller() string
 }
 
+var _ MetricNamer = &GeneralMetricNamer{}
+
 type GeneralMetricNamer struct {
-	Metric *metricquery.Metric
+	Metric     *metricquery.Metric
+	CallerName string
+}
+
+func (gmn *GeneralMetricNamer) Caller() string {
+	return gmn.CallerName
 }
 
 func (gmn *GeneralMetricNamer) QueryBuilder() querybuilder.QueryBuilder {
@@ -24,7 +34,7 @@ func (gmn *GeneralMetricNamer) QueryBuilder() querybuilder.QueryBuilder {
 }
 
 func (gmn *GeneralMetricNamer) BuildUniqueKey() string {
-	return gmn.Metric.BuildUniqueKey()
+	return gmn.CallerName + "/" + gmn.Metric.BuildUniqueKey()
 }
 
 func (gmn *GeneralMetricNamer) Validate() error {

--- a/pkg/metricquery/type.go
+++ b/pkg/metricquery/type.go
@@ -27,10 +27,10 @@ const (
 
 var (
 	NotMatchWorkloadError  = fmt.Errorf("metric type %v, but no WorkloadNamerInfo provided", WorkloadMetricType)
-	NotMatchContainerError = fmt.Errorf("metric type %v, but no WorkloadNamerInfo provided", ContainerMetricType)
-	NotMatchPodError       = fmt.Errorf("metric type %v, but no WorkloadNamerInfo provided", PodMetricType)
-	NotMatchNodeError      = fmt.Errorf("metric type %v, but no WorkloadNamerInfo provided", NodeMetricType)
-	NotMatchPromError      = fmt.Errorf("metric type %v, but no WorkloadNamerInfo provided", PromQLMetricType)
+	NotMatchContainerError = fmt.Errorf("metric type %v, but no ContainerNamerInfo provided", ContainerMetricType)
+	NotMatchPodError       = fmt.Errorf("metric type %v, but no PodNamerInfo provided", PodMetricType)
+	NotMatchNodeError      = fmt.Errorf("metric type %v, but no NodeNamerInfo provided", NodeMetricType)
+	NotMatchPromError      = fmt.Errorf("metric type %v, but no PromNamerInfo provided", PromQLMetricType)
 )
 
 type Metric struct {
@@ -153,7 +153,7 @@ func (m *Metric) keyByWorkload() string {
 		m.Workload.APIVersion,
 		m.Workload.Namespace,
 		m.Workload.Name,
-		selectorStr}, "-")
+		selectorStr}, "_")
 }
 
 func (m *Metric) keyByContainer() string {
@@ -168,7 +168,7 @@ func (m *Metric) keyByContainer() string {
 		m.Container.WorkloadName,
 		m.Container.PodName,
 		m.Container.ContainerName,
-		selectorStr}, "-")
+		selectorStr}, "_")
 }
 
 func (m *Metric) keyByPod() string {
@@ -181,7 +181,7 @@ func (m *Metric) keyByPod() string {
 		strings.ToLower(m.MetricName),
 		m.Pod.Namespace,
 		m.Pod.Name,
-		selectorStr}, "-")
+		selectorStr}, "_")
 }
 func (m *Metric) keyByNode() string {
 	selectorStr := ""
@@ -192,7 +192,7 @@ func (m *Metric) keyByNode() string {
 		string(m.Type),
 		strings.ToLower(m.MetricName),
 		m.Node.Name,
-		selectorStr}, "-")
+		selectorStr}, "_")
 }
 
 func (m *Metric) keyByPromQL() string {
@@ -205,7 +205,7 @@ func (m *Metric) keyByPromQL() string {
 		m.Prom.Namespace,
 		strings.ToLower(m.MetricName),
 		m.Prom.QueryExpr,
-		selectorStr}, "-")
+		selectorStr}, "_")
 }
 
 // Query is used to do query for different data source. you can extends it with your data source query

--- a/pkg/prediction/config/types.go
+++ b/pkg/prediction/config/types.go
@@ -10,7 +10,20 @@ type AlgorithmModelConfig struct {
 	UpdateInterval time.Duration
 }
 
+type ModelInitMode string
+
+const (
+	// means recover or init the algorithm model directly from history datasource, this process may block because it is time consuming for data fetching & model gen
+	ModelInitModeHistory ModelInitMode = "history"
+	// means recover or init the algorithm model from real time datasource async, predictor can not do predicting before the data is accumulating to window length
+	// this is more safe to do some data accumulating and make the prediction data is robust.
+	ModelInitModeLazyTraining ModelInitMode = "lazytraining"
+	// means recover or init the model from a checkpoint, it can be restored directly and immediately to do predict.
+	ModelInitModeCheckpoint ModelInitMode = "checkpoint"
+)
+
 type Config struct {
+	InitMode   *ModelInitMode
 	DSP        *v1alpha1.DSP
 	Percentile *v1alpha1.Percentile
 }

--- a/pkg/prediction/dsp/prediction.go
+++ b/pkg/prediction/dsp/prediction.go
@@ -35,6 +35,10 @@ type periodicSignalPrediction struct {
 	modelConfig config.AlgorithmModelConfig
 }
 
+func (p *periodicSignalPrediction) QueryPredictionStatus(ctx context.Context, metricNamer metricnaming.MetricNamer) (prediction.Status, error) {
+	panic("implement me")
+}
+
 func NewPrediction(realtimeProvider providers.RealTime, historyProvider providers.History, mc config.AlgorithmModelConfig) prediction.Interface {
 	withCh, delCh := make(chan prediction.QueryExprWithCaller), make(chan prediction.QueryExprWithCaller)
 	return &periodicSignalPrediction{

--- a/pkg/prediction/generic.go
+++ b/pkg/prediction/generic.go
@@ -26,6 +26,10 @@ const (
 	StatusNotStarted Status = "NotStarted"
 	StatusUnknown    Status = "Unknown"
 	StatusDeleted    Status = "Deleted"
+	// StatusInitializing means the prediction model is accumulating data until it satisfy the user specified time window such as 12h or 3d or 1w when use some real time data provider
+	// if support recover from checkpoint, then it maybe faster
+	StatusInitializing Status = "Initializing"
+	StatusExpired      Status = "Expired"
 )
 
 type WithMetricEvent struct {

--- a/pkg/prediction/interface.go
+++ b/pkg/prediction/interface.go
@@ -19,6 +19,9 @@ type Interface interface {
 
 	DeleteQuery(metricNamer metricnaming.MetricNamer, caller string) error
 
+	// QueryPredictionStatus return the metricNamer prediction status. it is predictable only when it is ready
+	QueryPredictionStatus(ctx context.Context, metricNamer metricnaming.MetricNamer) (Status, error)
+
 	// QueryRealtimePredictedValues returns predicted values based on the specified query expression
 	QueryRealtimePredictedValues(ctx context.Context, metricNamer metricnaming.MetricNamer) ([]*common.TimeSeries, error)
 

--- a/pkg/prediction/percentile/aggregate_signal.go
+++ b/pkg/prediction/percentile/aggregate_signal.go
@@ -15,6 +15,7 @@ type aggregateSignal struct {
 	lastSampleTime    time.Time
 	minSampleWeight   float64
 	totalSamplesCount int
+	sampleInterval    time.Duration
 	creationTime      time.Time
 	labels            []common.Label
 }
@@ -30,10 +31,16 @@ func (a *aggregateSignal) addSample(sampleTime time.Time, sampleValue float64) {
 	a.totalSamplesCount++
 }
 
+// largest is 290 years, so it can not be overflow
+func (a *aggregateSignal) GetAggregationWindowLength() time.Duration {
+	return time.Duration(a.totalSamplesCount) * a.sampleInterval
+}
+
 func newAggregateSignal(c *internalConfig) *aggregateSignal {
 	return &aggregateSignal{
 		histogram:       vpa.NewHistogram(c.histogramOptions),
 		minSampleWeight: c.minSampleWeight,
 		creationTime:    time.Now(),
+		sampleInterval:  c.sampleInterval,
 	}
 }

--- a/pkg/providers/prom/prometheus.go
+++ b/pkg/providers/prom/prometheus.go
@@ -37,7 +37,7 @@ func (p *prom) QueryTimeSeries(namer metricnaming.MetricNamer, startTime time.Ti
 		klog.Errorf("Failed to BuildQuery: %v", err)
 		return nil, err
 	}
-	klog.V(6).Infof("QueryTimeSeries metricNamer %v, timeout: %v", namer.BuildUniqueKey(), p.config.Timeout)
+	klog.V(6).Infof("QueryTimeSeries metricNamer %v, timeout: %v, query: %v", namer.BuildUniqueKey(), p.config.Timeout, promQuery.Prometheus.Query)
 	timeoutCtx, cancelFunc := gocontext.WithTimeout(gocontext.Background(), p.config.Timeout)
 	defer cancelFunc()
 	timeSeries, err := p.ctx.QueryRangeSync(timeoutCtx, promQuery.Prometheus.Query, startTime, endTime, step)
@@ -59,7 +59,7 @@ func (p *prom) QueryLatestTimeSeries(namer metricnaming.MetricNamer) ([]*common.
 	//end := time.Now()
 	// avoid no data latest. multiply 2
 	//start := end.Add(-step * 2)
-	klog.V(6).Infof("QueryLatestTimeSeries metricNamer %v, timeout: %v", namer.BuildUniqueKey(), p.config.Timeout)
+	klog.V(6).Infof("QueryLatestTimeSeries metricNamer %v, timeout: %v, query: %v", namer.BuildUniqueKey(), p.config.Timeout, promQuery.Prometheus.Query)
 	timeoutCtx, cancelFunc := gocontext.WithTimeout(gocontext.Background(), p.config.Timeout)
 	defer cancelFunc()
 	timeSeries, err := p.ctx.QuerySync(timeoutCtx, promQuery.Prometheus.Query)


### PR DESCRIPTION
…async until the data is accumlulating enough

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Feature

#### What this PR does / why we need it:
support init percentile model by different modes, by default, it always use history mode, keep the original logic.
for recommendation, it is once task use original algorithm, so it does not impact.
for tsp, it has params and caller, so it does not impact.
for evpa, use lazytrainning mode to do predict until it is accumulating data to enough window. this way the prediction is more robust and safe.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #212 

#### Special notes for your reviewer:

