### PR TITLE
fix analytics and recommendation status update

### DIFF
--- a/pkg/controller/analytics/analytics_controller.go
+++ b/pkg/controller/analytics/analytics_controller.go
@@ -358,7 +358,7 @@ func (c *Controller) GetIdentities(ctx context.Context, analytics *analysisv1alp
 func (c *Controller) UpdateStatus(ctx context.Context, analytics *analysisv1alph1.Analytics, newStatus *analysisv1alph1.AnalyticsStatus) {
 	if !equality.Semantic.DeepEqual(&analytics.Status, newStatus) {
 		analytics.Status = *newStatus
-		err := c.Update(ctx, analytics)
+		err := c.Status().Update(ctx, analytics)
 		if err != nil {
 			c.Recorder.Event(analytics, corev1.EventTypeNormal, "FailedUpdateStatus", err.Error())
 			klog.Errorf("Failed to update status, Analytics %s error %v", klog.KObj(analytics), err)

--- a/pkg/controller/recommendation/recommendation_controller.go
+++ b/pkg/controller/recommendation/recommendation_controller.go
@@ -138,7 +138,7 @@ func (c *Controller) UpdateStatus(ctx context.Context, recommendation *analysisv
 		timeNow := metav1.Now()
 		recommendation.Status.LastUpdateTime = &timeNow
 
-		err := c.Update(ctx, recommendation)
+		err := c.Status().Update(ctx, recommendation)
 		if err != nil {
 			c.Recorder.Event(recommendation, v1.EventTypeWarning, "FailedUpdateStatus", err.Error())
 			klog.Errorf("Failed to update status, Recommendation %s error %v", klog.KObj(recommendation), err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
/kind bugfix

#### What this PR does / why we need it:
`analytics` and `recommendation` Controller can not update resource's status correctly,  because we should use `Client.Status().Update()` to update `status`, `Client.Update()` can not update `status` field.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

