### PR TITLE
After creating an ehpa with a behavior, synchronize the behavior to its corresponding hpa

### DIFF
--- a/pkg/controller/ehpa/hpa.go
+++ b/pkg/controller/ehpa/hpa.go
@@ -117,7 +117,7 @@ func (c *EffectiveHPAController) NewHPAObject(ctx context.Context, ehpa *autosca
 	var behavior *autoscalingv2.HorizontalPodAutoscalerBehavior
 	// Behavior works in k8s version > 1.18
 	if c.K8SVersion.Minor() >= 18 && ehpa.Spec.Behavior != nil {
-		behavior = hpa.Spec.Behavior
+		behavior = ehpa.Spec.Behavior
 	} else {
 		behavior = nil
 	}


### PR DESCRIPTION


#### What type of PR is this?
fix bug

#### What this PR does / why we need it:
When the behavior of ehpa is not nil, the behavior of ehpa should be synchronized instead of the behavior of hpa.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.com/gocrane/crane/issues/310
#### Special notes for your reviewer:

