### PR TITLE
If ehpa is configured with prediction but does not contain predictable metrics, then no tsp object is created

### DIFF
--- a/pkg/controller/ehpa/effective_hpa_controller.go
+++ b/pkg/controller/ehpa/effective_hpa_controller.go
@@ -78,7 +78,7 @@ func (c *EffectiveHPAController) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// reconcile prediction if enabled
-	if utils.IsEHPAPredictionEnabled(ehpa) {
+	if utils.IsEHPAPredictionEnabled(ehpa) && utils.IsEHPAHasPredictionMetric(ehpa) {
 		prediction, err := c.ReconcilePredication(ctx, ehpa)
 		if err != nil {
 			setCondition(newStatus, autoscalingapi.Ready, metav1.ConditionFalse, "FailedReconcilePrediction", err.Error())

--- a/pkg/controller/ehpa/hpa.go
+++ b/pkg/controller/ehpa/hpa.go
@@ -186,7 +186,7 @@ func (c *EffectiveHPAController) GetHPAMetrics(ctx context.Context, ehpa *autosc
 		for _, metric := range metrics {
 			// generate a custom metric for resource metric
 			if metric.Type == autoscalingv2.ResourceMetricSourceType {
-				name := GetPredictionMetricName(metric.Resource.Name)
+				name := utils.GetPredictionMetricName(metric.Resource.Name)
 				if len(name) == 0 {
 					continue
 				}
@@ -277,16 +277,6 @@ func GetCronMetricSpecsForHPA(ehpa *autoscalingapi.EffectiveHorizontalPodAutosca
 		},
 	})
 	return metricSpecs
-}
-
-// GetPredictionMetricName return metric name used by prediction
-func GetPredictionMetricName(Name v1.ResourceName) string {
-	switch Name {
-	case v1.ResourceCPU:
-		return known.MetricNamePodCpuUsage
-	default:
-		return ""
-	}
 }
 
 func setHPACondition(status *autoscalingapi.EffectiveHorizontalPodAutoscalerStatus, conditions []autoscalingv2.HorizontalPodAutoscalerCondition) {

--- a/pkg/controller/ehpa/predict.go
+++ b/pkg/controller/ehpa/predict.go
@@ -3,6 +3,7 @@ package ehpa
 import (
 	"context"
 	"fmt"
+	"github.com/gocrane/crane/pkg/utils"
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
@@ -127,7 +128,7 @@ func (c *EffectiveHPAController) NewPredictionObject(ehpa *autoscalingapi.Effect
 	for _, metric := range ehpa.Spec.Metrics {
 		// Convert resource metric into prediction metric
 		if metric.Type == autoscalingv2.ResourceMetricSourceType {
-			metricName := GetPredictionMetricName(metric.Resource.Name)
+			metricName := utils.GetPredictionMetricName(metric.Resource.Name)
 			if len(metricName) == 0 {
 				continue
 			}

--- a/pkg/utils/ehpa.go
+++ b/pkg/utils/ehpa.go
@@ -1,11 +1,39 @@
 package utils
 
-import autoscalingapi "github.com/gocrane/api/autoscaling/v1alpha1"
+import (
+	autoscalingapi "github.com/gocrane/api/autoscaling/v1alpha1"
+	"github.com/gocrane/crane/pkg/known"
+	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
+	v1 "k8s.io/api/core/v1"
+)
 
 func IsEHPAPredictionEnabled(ehpa *autoscalingapi.EffectiveHorizontalPodAutoscaler) bool {
 	return ehpa.Spec.Prediction != nil && ehpa.Spec.Prediction.PredictionWindowSeconds != nil && ehpa.Spec.Prediction.PredictionAlgorithm != nil
 }
 
+func IsEHPAHasPredictionMetric(ehpa *autoscalingapi.EffectiveHorizontalPodAutoscaler) bool {
+	for _, metric := range ehpa.Spec.Metrics {
+		if metric.Type == autoscalingv2.ResourceMetricSourceType {
+			metricName := GetPredictionMetricName(metric.Resource.Name)
+			if len(metricName) == 0 {
+				continue
+			}
+			return true
+		}
+	}
+	return false
+}
+
 func IsEHPACronEnabled(ehpa *autoscalingapi.EffectiveHorizontalPodAutoscaler) bool {
 	return len(ehpa.Spec.Crons) > 0
+}
+
+// GetPredictionMetricName return metric name used by prediction
+func GetPredictionMetricName(Name v1.ResourceName) string {
+	switch Name {
+	case v1.ResourceCPU:
+		return known.MetricNamePodCpuUsage
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
If ehpa is configured with prediction but does not contain predictable metrics, ehpa conotroller will throw error like below:
> E0531 17:15:57.094143       1 predict.go:71] Failed to create TimeSeriesPrediction khrd-geom-middleware-prod/ehpa-kigma-render-service-prod-hpa-preview error admission webhook "vprediction.crane.io" denied the request: PredictionMetrics is null
So we need to add a judgment condition, in this case, no tsp object is created.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

