### PR TITLE
change agent log level to 2

### DIFF
--- a/deploy/crane-agent/daemonset.yaml
+++ b/deploy/crane-agent/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
           imagePullPolicy: Always
           command:
             - /crane-agent
-            - -v=4
+            - -v=2
           name: crane-agent
           volumeMounts:
             - mountPath: /sys


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->
#### What this PR does / why we need it:
There are many disturbed logs from cadvisor manager whose log level is 4, so change agent log level to 2 and be consistent with level in helm chart.
