### PR TITLE
fix(web): remove unnecessary grafana dashboard query str

### DIFF
--- a/pkg/web/src/apis/grafanaApi.ts
+++ b/pkg/web/src/apis/grafanaApi.ts
@@ -22,7 +22,7 @@ export const grafanaApi = createApi({
     fetchDashboardList: builder.query<any, FetchDashboardListArgs>({
       query: args => {
         return {
-          url: `${args.craneUrl ?? ''}/grafana/api/search?query=%`,
+          url: `${args.craneUrl ?? ''}/grafana/api/search`,
           method: 'get'
         };
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Remove unnecessary grafana dashboard query str

#### What this PR does / why we need it:
In some cases, adding ?query=% to /grafana/api/search will cause an error.
<img width="404" alt="image" src="https://user-images.githubusercontent.com/28004715/180723750-5d9e401d-808f-4226-9a15-06764cad5abe.png">

And I have tried that everything is working fine after removing ?query=%

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

