### PR TITLE
Fix: ci build arm images

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -414,6 +414,16 @@ jobs:
             | metric-adapter:${{steps.image-tags.outputs.image-tags}} | docker pull gocrane/metric-adapter:${{steps.image-tags.outputs.image-tags}} |
             | craned:${{steps.image-tags.outputs.image-tags}}         | docker pull gocrane/craned:${{steps.image-tags.outputs.image-tags}}         |
 
+            Quick Deploy - Helm
+            ```bash
+            helm repo add crane https://finops-helm.pkg.coding.net/gocrane/gocrane
+            helm install crane -n crane-system --create-namespace \
+                               --set craned.image.tag=gocrane/craned:${{steps.image-tags.outputs.image-tags}} \
+                               --set metricAdapter.image.tag=gocrane/metric-adapter:${{steps.image-tags.outputs.image-tags}} \
+                               --set craneAgent.image.tag=gocrane/crane-agent:${{steps.image-tags.outputs.image-tags}} \
+                               --set cranedDashboard.image.tag=gocrane/dashboard:${{steps.image-tags.outputs.image-tags}} crane/crane
+            ```
+
             ---
 
             #### Coding Registry
@@ -427,6 +437,16 @@ jobs:
             | metric-adapter:${{steps.image-tags.outputs.image-tags}} | docker pull finops-docker.pkg.coding.net/gocrane/crane/metric-adapter:${{steps.image-tags.outputs.image-tags}} |
             | craned:${{steps.image-tags.outputs.image-tags}}         | docker pull finops-docker.pkg.coding.net/gocrane/crane/craned:${{steps.image-tags.outputs.image-tags}}         |
 
+            Quick Deploy - Helm
+            ```bash
+            helm repo add crane https://finops-helm.pkg.coding.net/gocrane/gocrane
+            helm install crane -n crane-system --create-namespace \
+                               --set craned.image.tag=finops-docker.pkg.coding.net/gocrane/crane/craned:${{steps.image-tags.outputs.image-tags}} \
+                               --set metricAdapter.image.tag=finops-docker.pkg.coding.net/gocrane/crane/metric-adapter:${{steps.image-tags.outputs.image-tags}} \
+                               --set craneAgent.image.tag=finops-docker.pkg.coding.net/gocrane/crane/crane-agent:${{steps.image-tags.outputs.image-tags}} \
+                               --set cranedDashboard.image.tag=finops-docker.pkg.coding.net/gocrane/crane/dashboard:${{steps.image-tags.outputs.image-tags}} crane/crane
+            ```
+
             ---
 
             #### Ghcr Registry
@@ -439,5 +459,16 @@ jobs:
             | dashboard:${{steps.image-tags.outputs.image-tags}}      | docker pull ghcr.io/gocrane/crane/dashboard:${{steps.image-tags.outputs.image-tags}}      |
             | metric-adapter:${{steps.image-tags.outputs.image-tags}} | docker pull ghcr.io/gocrane/crane/metric-adapter:${{steps.image-tags.outputs.image-tags}} |
             | craned:${{steps.image-tags.outputs.image-tags}}         | docker pull ghcr.io/gocrane/crane/craned:${{steps.image-tags.outputs.image-tags}}         |
+
+            Quick Deploy - Helm
+            ```bash
+            helm repo add crane https://finops-helm.pkg.coding.net/gocrane/gocrane
+            helm install crane -n crane-system --create-namespace \
+                               --set craned.image.tag=ghcr.io/gocrane/crane/craned:${{steps.image-tags.outputs.image-tags}} \
+                               --set metricAdapter.image.tag=ghcr.io/gocrane/crane/metric-adapter:${{steps.image-tags.outputs.image-tags}} \
+                               --set craneAgent.image.tag=ghcr.io/gocrane/crane/crane-agent:${{steps.image-tags.outputs.image-tags}} \
+                               --set cranedDashboard.image.tag=ghcr.io/gocrane/crane/dashboard:${{steps.image-tags.outputs.image-tags}} crane/crane
+            ```
+
             <!-- Created by actions-cool/maintain-one-comment -->
           body-include: '<!-- Created by actions-cool/maintain-one-comment -->'

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,10 @@ ARG PKGNAME
 ARG BUILD
 
 WORKDIR /go/src/github.com/gocrane/crane
+
+# Add build deps
+RUN apk add build-base
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -22,7 +26,8 @@ COPY pkg pkg/
 COPY cmd cmd/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -a -o ${PKGNAME} /go/src/github.com/gocrane/crane/cmd/${PKGNAME}/main.go
+RUN env
+RUN go build -ldflags="${LDFLAGS}" -a -o ${PKGNAME} /go/src/github.com/gocrane/crane/cmd/${PKGNAME}/main.go
 FROM alpine:3.13.5
 RUN apk add --no-cache tzdata
 WORKDIR /

--- a/docs/mirror.md
+++ b/docs/mirror.md
@@ -1,11 +1,88 @@
-# Mirror Repo
+# Mirror Resources
 
-
-## About mirror repo
+## About mirror resources
 
 Because of various network issues, it is difficult to access GitHub resources such as GitHub Repo, GitHub Release, GitHub Raw Content `raw.githubusercontent.com` in some regions.
 
 For a better experience, GoCrane offers several additional mirror repositories for you, but with some latency.
+
+## Image Registry
+
+GoCrane provides a friendly way to use images to deploy and test.
+
+GoCrane builds images based on the CI(GitHub Action).
+
+### Platforms
+
+GoCrane now supports linux/amd64 and linux/arm64.
+
+GoCrane still cares about arm users, like apple m1/m2.
+
+### Repo
+Because of the network problems, GoCrane pushes the images to three different repo at the same time.
+
+!!! tips
+    Click these links to see details.
+- [DockerHub](https://hub.docker.com/u/gocrane)
+- [Coding](https://finops.coding.net/public-artifacts/gocrane/crane/packages)
+- [GitHub Container Registry](https://github.com/orgs/gocrane/packages?repo_name=crane)
+
+If you locate in China, we recommend using the Coding repo. It's fast than other registry repo.
+
+If you locate outside of China, we recommend using DockerHub and GitHub Container Registry. However, if you use Coding, the Registry may be slow.
+
+### Build logic
+
+- Each branch
+
+    You can try the new features based on the branch images. In addition, we still reserve the early images.
+
+- Each pull request
+
+    When you make a pull request to the crane repo, that will trigger CI to build images. In addition, a comment will include image info to the pull request when CI completes.
+
+### How to use the images?
+
+Here use the main branch as an example.
+The git commit hash is abc123.
+
+#### Base on the branch name
+
+!!! tips
+    The branch name still points to the last commit. Don't forget to re-pull the images when you want to try the new features.
+
+=== "DockerHub"
+    ```bash
+    docker pull gocrane/craned:main
+    ```
+
+=== "Coding"
+    ```bash
+    docker pull finops-docker.pkg.coding.net/gocrane/crane/craned:main
+    ```
+
+=== "GitHub Container Registry"
+    ```bash
+    docker pull ghcr.io/gocrane/crane/craned:main
+    ```
+
+#### Base on the branch name and the specific commit hash
+
+=== "DockerHub"
+    ```bash
+    docker pull gocrane/craned:main-abc123
+    ```
+
+=== "Coding"
+    ```bash
+    docker pull finops-docker.pkg.coding.net/gocrane/crane/craned:main-abc123
+    ```
+
+=== "GitHub Container Registry"
+    ```bash
+    docker pull ghcr.io/gocrane/crane/craned:main-abc123
+    ```
+
 
 ## Helm Resources
 

--- a/docs/mirror.zh.md
+++ b/docs/mirror.zh.md
@@ -1,10 +1,89 @@
-# 镜像仓库
+# 镜像资源
 
-## 关于镜像仓库
+## 关于镜像资源
 
 因为各种网络问题，导致部分地域难以访问GitHub 资源，如GitHub Repo, GitHub Release, GitHub Raw Content `raw.githubusercontent.com`。
 
 为了更好的使用体验，GoCrane 为您额外提供了多个镜像仓库，但具有一定的时延。
+
+## Image Registry
+
+GoCrane提供了一种友好的方式来使用镜像进行部署和测试。
+
+GoCrane使用CI(GitHub Action)进行镜像构建。
+
+### Platforms
+
+GoCrane 现在支持 linux/amd64 和 linux/arm64。
+
+GoCrane 也在关注ARM用户，譬如 apple m1/m2。
+
+### Repo
+
+由于网络原因，GoCrane 将同时将镜像推送到三个镜像仓库。
+
+!!! tips
+    点击链接，查阅更多
+
+- [DockerHub](https://hub.docker.com/u/gocrane)
+- [Coding](https://finops.coding.net/public-artifacts/gocrane/crane/packages)
+- [GitHub Container Registry](https://github.com/orgs/gocrane/packages?repo_name=crane)
+
+如果你在中国，我们推荐使用 Coding。该仓库的速度比其他两个快。
+
+如果你在中国境外，我们推荐你使用 DockHub以及GHCR。如果你使用Coding，速度上面不太理想。
+
+### Build logic
+
+- 每个分支
+
+  你可以使用该分支镜像尝试最新的特性。此外，我们依旧保存较早之前的镜像。
+
+- 每个pull request
+
+  当你发起一个pull request到crane repo的时候，将会自动触发CI任务来构建对应的镜像。CI会将最后的镜像结果通过评论的方式附加在对应的pull request中。
+
+### How to use the images?
+
+这里将使用 main 分支作为例子。
+Git commit hash 为 abc123。
+
+#### Base on the branch name
+
+!!! tips
+    branch name的镜像一直指向最新的Git commit。当你想尝试新特性的时候，不要忘记重新拉取镜像。
+
+=== "DockerHub"
+    ```bash
+    docker pull gocrane/craned:main
+    ```
+
+=== "Coding"
+    ```bash
+    docker pull finops-docker.pkg.coding.net/gocrane/crane/craned:main
+    ```
+
+=== "GitHub Container Registry"
+    ```bash
+    docker pull ghcr.io/gocrane/crane/craned:main
+    ```
+
+#### Base on the branch name and the specific commit hash
+
+=== "DockerHub"
+    ```bash
+    docker pull gocrane/craned:main-abc123
+    ```
+
+=== "Coding"
+    ```bash
+    docker pull finops-docker.pkg.coding.net/gocrane/crane/craned:main-abc123
+    ```
+
+=== "GitHub Container Registry"
+    ```bash
+    docker pull ghcr.io/gocrane/crane/craned:main-abc123
+    ```
 
 ## Helm Resources
 

--- a/docs/mirror.zh_TW.md
+++ b/docs/mirror.zh_TW.md
@@ -1,6 +1,6 @@
-# 鏡像倉庫
+# 鏡像資源
 
-## 關於鏡像倉庫
+## 關於鏡像資源
 
 因為各種網絡問題，導致部分地域難以訪問GitHub 資源，如GitHub Repo, GitHub Release, GitHub Raw Content `raw.githubusercontent.com`。
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ plugins:
           Replicas Recommendation: 副本数推荐
           Proposals: 提案
           Contributing: 贡献
-          Mirror Repo: 镜像仓库
+          Mirror Resource: 镜像资源
           Code Standard: 代码标准
           Roadmap: 路线图
           Overview: 概述
@@ -69,7 +69,7 @@ plugins:
           Replicas Recommendation: 副本數推薦
           Proposals: 提案
           Contributing: 貢獻
-          Mirror Repo: 鏡像倉庫
+          Mirror Resource: 鏡像資源
           Code Standard: 代碼標準
           Roadmap: 技術路線
           Overview: 概述
@@ -121,4 +121,4 @@ nav:
   - Code Standard: code-standards.md
   - Roadmap:
     - 2022: roadmaps/roadmap-2022.md
-  - Mirror Repo: mirror.md
+  - Mirror Resource: mirror.md


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Fix: arm image not working.

#### What happened?
 The `go build` built the x86 binary in the arm env because of the const build args - `CGO_ENABLED=0 GOOS=linux GOARCH=amd64`.
But we don't need to set the `go build` args in the Dockerfile.
The `go build` can get the compile flags from the build env.

---

```log
root@VM-0-28-ubuntu:~# uname -a
Linux VM-0-28-ubuntu 5.4.0-104-generic #118-Ubuntu SMP Wed Mar 2 19:03:41 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
root@VM-0-28-ubuntu:~# file metric-adapter 
metric-adapter: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-aarch64.so.1, Go BuildID=ymgyrPjIz3jkF6OdMcLJ/iH3dROJRkpIzlx57H06V/g1YpaX-I2yDYE-jFtK-b/iKOPV8g7qn4jOMga5Izi, not stripped
```
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/35299017/183705422-8a906a8a-eceb-4049-9bbc-d07630c57150.png">






