### PR TITLE
Fix: CI task - golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -175,7 +175,7 @@ jobs:
         
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - name: Setup Go environment

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -185,7 +185,7 @@ jobs:
           go-version: 1.17 # optional
           
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.45.2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

Fix golangci-lint error.

Using macOS, we can get the 14GB RAM in the actions.

Upgrade  golangci/golangci-lint-action versions.

https://github.com/zsnmwy/crane/runs/7833264873?check_suite_focus=true#step:4:23

<img width="1352" alt="image" src="https://user-images.githubusercontent.com/35299017/184589010-bfe3d53f-67ed-4b8a-bf56-2b282b01689e.png">

