### PR TITLE
always collect node local metrics when node resource controller is enabled.

### DIFF
--- a/cmd/crane-agent/app/agent.go
+++ b/cmd/crane-agent/app/agent.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,6 +57,11 @@ func NewAgentCommand(ctx context.Context) *cobra.Command {
 			if err := opts.Validate(); err != nil {
 				klog.Exitf("Opts validate failed: %v", err)
 			}
+
+			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+				klog.Infof("FLAG: --%s=%q\n", flag.Name, flag.Value)
+			})
+
 			if err := Run(ctx, opts); err != nil {
 				klog.Exit(err)
 			}
@@ -71,7 +77,6 @@ func NewAgentCommand(ctx context.Context) *cobra.Command {
 
 func Run(ctx context.Context, opts *options.Options) error {
 	hostname := getHostName(opts.HostnameOverride)
-
 	healthCheck := metrics.NewHealthCheck(opts.MaxInactivity)
 	metrics.RegisterCraneAgent()
 

--- a/pkg/ensurance/collector/nodelocal/nodelocal.go
+++ b/pkg/ensurance/collector/nodelocal/nodelocal.go
@@ -22,8 +22,9 @@ var nodeLocalMetric = make(map[string][]types.MetricName, 10)
 var collectFuncMap = make(map[string]collectFunc, 10)
 
 func registerCollector(collectorName string, metricsNames []types.MetricName, collectorFunc collectFunc) {
+	klog.Infof("Registering node local metrics collector %s", collectorName)
 	if _, ok := nodeLocalMetric[collectorName]; ok {
-		klog.Infof("Warning: node local metrics collectorName %s is registered, not to register again", collectorName)
+		klog.Infof("Node local metrics collector %s is registered, not to register again", collectorName)
 		return
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Feature

#### What this PR does / why we need it:
Currently, node resource controller is enabled by default, but node local agent metrics collector is not, which cause a repeated error in crane agent.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

