### PR TITLE
fix craned deployment yaml

### DIFF
--- a/deploy/craned/deployment.yaml
+++ b/deploy/craned/deployment.yaml
@@ -73,8 +73,8 @@ spec:
             defaultMode: 420
             secretName: webhook-server-tls
         - name: config
-            configMap:
-              name: recommendation-configuration
+          configMap:
+            name: recommendation-configuration
         - name: nginx-conf
           configMap:
             name: nginx-conf


### PR DESCRIPTION
Fixes  error: error parsing deploy/craned/deployment.yaml: error converting YAML to JSON: yaml: line 62: mapping values are not allowed in this context

