### PR TITLE
make function GetPodTemplate and IsHPAControlledByEHPA more precise

### DIFF
--- a/pkg/controller/ehpa/hpa_event_handler.go
+++ b/pkg/controller/ehpa/hpa_event_handler.go
@@ -1,8 +1,6 @@
 package ehpa
 
 import (
-	"strings"
-
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -10,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 
 	"github.com/gocrane/crane/pkg/metrics"
+	"github.com/gocrane/crane/pkg/utils"
 )
 
 type hpaEventHandler struct {
@@ -38,7 +37,7 @@ func (h *hpaEventHandler) Update(evt event.UpdateEvent, q workqueue.RateLimiting
 		for _, cond := range newHpa.Status.Conditions {
 			if cond.Reason == "SucceededRescale" || cond.Reason == "SucceededOverloadRescale" {
 				scaleType := "hpa"
-				if strings.HasPrefix("ehpa-", newHpa.Name) {
+				if utils.IsHPAControlledByEHPA(newHpa) {
 					scaleType = "ehpa"
 				}
 

--- a/pkg/utils/hpa.go
+++ b/pkg/utils/hpa.go
@@ -6,10 +6,10 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	autoscalingapi "github.com/gocrane/api/autoscaling/v1alpha1"
-
 	"github.com/gocrane/crane/pkg/known"
 )
 
@@ -58,4 +58,17 @@ func GetEHPAFromScaleTarget(context context.Context, kubeClient client.Client, n
 	}
 
 	return nil, nil
+}
+
+func IsHPAControlledByEHPA(hpa *autoscalingv2.HorizontalPodAutoscaler) bool {
+	for _, ownerReference := range hpa.OwnerReferences {
+		gv, err := schema.ParseGroupVersion(ownerReference.APIVersion)
+		if err != nil {
+			return false
+		}
+		if gv.Group == autoscalingapi.GroupName && ownerReference.Kind == "EffectiveHorizontalPodAutoscaler" {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/utils/pod_template_test.go
+++ b/pkg/utils/pod_template_test.go
@@ -1,0 +1,99 @@
+package utils
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetPodTemplate(t *testing.T) {
+	ctx := context.TODO()
+	testNamespace := "test-namespace"
+	testName := "test-name"
+	testImage := "test-image"
+	testCases := []struct {
+		object     client.Object
+		kind       string
+		apiVersion string
+	}{
+		{
+			object: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      testName,
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: testImage,
+								},
+							},
+						},
+					},
+				},
+			},
+			kind:       "Deployment",
+			apiVersion: "apps/v1",
+		},
+		{
+			object: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      testName,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: testImage,
+								},
+							},
+						},
+					},
+				},
+			},
+			kind:       "StatefulSet",
+			apiVersion: "apps/v1",
+		},
+		{
+			object: &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      testName,
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Image: testImage,
+								},
+							},
+						},
+					},
+				},
+			},
+			kind:       "DaemonSet",
+			apiVersion: "apps/v1",
+		},
+	}
+
+	for _, tc := range testCases {
+		fakeClient := fakeClient.NewClientBuilder().WithObjects(tc.object).Build()
+		podTemplate, err := GetPodTemplate(ctx, testNamespace, testName, tc.kind, tc.apiVersion, fakeClient)
+		if err != nil {
+			t.Errorf("get pod template error: %v", err)
+		}
+		if len(podTemplate.Spec.Containers) == 1 && podTemplate.Spec.Containers[0].Image != testImage {
+			t.Errorf("the container image of pod template is inconsistent: expect %s, actual is %s", testImage, podTemplate.Spec.Containers[0].Image)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
optimize

#### What this PR does / why we need it:
In the function GetPodTemplate, validates the apiVersion and turns "group/version" string into a GroupVersion struct so they could be exactly compared instead of strings.HasPrefix. The latter may be misjudged, like apps.kruise.io which also have StatefulSet.
In hpa_event_handler.go, use ownerRefenerce to determine if hpa is controlled by ehpa instead of strings.HasPrefix.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

