### PR TITLE
feat: use CoreDNS instead of kube-dns

### DIFF
--- a/deploy/craned/deployment.yaml
+++ b/deploy/craned/deployment.yaml
@@ -207,7 +207,7 @@ data:
         server craned.crane-system:8082;
     }
 
-    resolver kube-dns.kube-system.svc.cluster.local valid=5s;
+    resolver coredns.kube-system.svc.cluster.local valid=5s;
 
     server {
         server_name _;


### PR DESCRIPTION
#### What this PR does / why we need it:
CoreDNS became the default DNS service for Kubernetes 1.13+ onwards.

btw, we can set the dns service as the argument in helm



