### PR TITLE
fix: remove duplicated reset triggered map

### DIFF
--- a/pkg/ensurance/analyzer/analyzer.go
+++ b/pkg/ensurance/analyzer/analyzer.go
@@ -283,7 +283,6 @@ func (s *AnomalyAnalyzer) computeActionContext(aboveThreshold bool, key string, 
 			ac.Triggered = true
 		}
 	} else {
-		s.triggered[key] = 0
 		restored := utils.GetUint64FromMaps(key, s.restored)
 		restored++
 		// log how many times the actual usage below threshold


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
For QoS-Ensurance bug fixing.

#### What this PR does / why we need it:
Removing the duplicated action of reseting the triggered map would fix the bug of RESTORE IF-CONDITION(pkg/ensurance/analyzer/analyzer.go:295) never work.

#### Which issue(s) this PR fixes:  
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #637 

#### Special notes for your reviewer:
Sincerely
