### PR TITLE
add support for prom-adapter overrides 

### DIFF
--- a/cmd/craned/app/manager.go
+++ b/cmd/craned/app/manager.go
@@ -303,7 +303,7 @@ func initControllers(oomRecorder oom.Recorder, mgr ctrl.Manager, opts *options.O
 				AdapterConfig: opts.DataSourcePromConfig.AdapterConfig,
 			}
 			prometheus_adapter.SetExtensionLabels(opts.DataSourcePromConfig.AdapterExtensionLabels)
-			go pac.Reload()
+			go pac.Reload(mgr.GetRESTMapper())
 		}
 
 		if err := (&ehpa.SubstituteController{

--- a/cmd/craned/app/manager.go
+++ b/cmd/craned/app/manager.go
@@ -300,10 +300,11 @@ func initControllers(oomRecorder oom.Recorder, mgr ctrl.Manager, opts *options.O
 		} else if opts.DataSourcePromConfig.AdapterConfig != "" {
 			// PrometheusAdapterConfigFetcher
 			pac := &prometheus_adapter.PrometheusAdapterConfigFetcher{
+				RestMapper:    mgr.GetRESTMapper(),
 				AdapterConfig: opts.DataSourcePromConfig.AdapterConfig,
 			}
 			prometheus_adapter.SetExtensionLabels(opts.DataSourcePromConfig.AdapterExtensionLabels)
-			go pac.Reload(mgr.GetRESTMapper())
+			go pac.Reload()
 		}
 
 		if err := (&ehpa.SubstituteController{

--- a/pkg/controller/ehpa/predict.go
+++ b/pkg/controller/ehpa/predict.go
@@ -3,7 +3,6 @@ package ehpa
 import (
 	"context"
 	"fmt"
-
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/controller/ehpa/predict.go
+++ b/pkg/controller/ehpa/predict.go
@@ -165,7 +165,7 @@ func (c *EffectiveHPAController) NewPredictionObject(ehpa *autoscalingapi.Effect
 				if len(mrs.MetricRulesResource) > 0 {
 					metricRule = prometheus_adapter.MatchMetricRule(mrs.MetricRulesResource, metricName)
 					if metricRule == nil {
-						klog.Errorf("Got MetricRulesResource prometheus-adapter-resource Failed MetricMatches[%s] SeriesName[%s] MetricName[%s]", metricRule.MetricMatches, metricRule.SeriesName, metricName)
+						klog.Errorf("Got MetricRulesResource prometheus-adapter-resource Failed MetricName[%s]", metricName)
 					} else {
 						klog.V(4).Infof("Got MetricRulesResource prometheus-adapter-resource MetricMatches[%s] SeriesName[%s]", metricRule.MetricMatches, metricRule.SeriesName)
 						matchLabels = append(matchLabels, fmt.Sprintf("pod=~\"%s\"", utils.GetPodNameReg(ehpa.Spec.ScaleTargetRef.Name, ehpa.Spec.ScaleTargetRef.Kind)))
@@ -175,7 +175,7 @@ func (c *EffectiveHPAController) NewPredictionObject(ehpa *autoscalingapi.Effect
 				if len(mrs.MetricRulesCustomer) > 0 {
 					metricRule = prometheus_adapter.MatchMetricRule(mrs.MetricRulesCustomer, metricName)
 					if metricRule == nil {
-						klog.Errorf("Got MetricRulesCustomer prometheus-adapter-customer Failed MetricMatches[%s] SeriesName[%s] MetricName[%s]", metricRule.MetricMatches, metricRule.SeriesName, metricName)
+						klog.Errorf("Got MetricRulesCustomer prometheus-adapter-customer Failed MetricName[%s]", metricName)
 					} else {
 						klog.V(4).Infof("Got MetricRulesCustomer prometheus-adapter-customer MetricMatches[%s] SeriesName[%s]", metricRule.MetricMatches, metricRule.SeriesName)
 						if metric.Pods.Metric.Selector != nil {
@@ -189,7 +189,7 @@ func (c *EffectiveHPAController) NewPredictionObject(ehpa *autoscalingapi.Effect
 				if len(mrs.MetricRulesExternal) > 0 {
 					metricRule = prometheus_adapter.MatchMetricRule(mrs.MetricRulesExternal, metricName)
 					if metricRule == nil {
-						klog.Errorf("Got MetricRulesExternal prometheus-adapter-external Failed MetricMatches[%s] SeriesName[%s] MetricName[%s]", metricRule.MetricMatches, metricRule.SeriesName, metricName)
+						klog.Errorf("Got MetricRulesExternal prometheus-adapter-external Failed MetricName[%s]", metricName)
 					} else {
 						klog.V(4).Infof("Got MetricRulesExternal prometheus-adapter-external MetricMatches[%s] SeriesName[%s]", metricRule.MetricMatches, metricRule.SeriesName)
 						if metric.External.Metric.Selector != nil {
@@ -206,7 +206,7 @@ func (c *EffectiveHPAController) NewPredictionObject(ehpa *autoscalingapi.Effect
 				var err error
 				expressionQuery, err = metricRule.QueryForSeries(ehpa.Namespace, append(mrs.ExtensionLabels, matchLabels...))
 				if err != nil {
-					klog.Errorf("Got promSelector prometheus-adapter %v", err)
+					klog.Errorf("Got promSelector prometheus-adapter %v %v", metricRule, err)
 				} else {
 					klog.V(4).Infof("Got expressionQuery [%s] from prometheus-adapter ", expressionQuery)
 				}

--- a/pkg/controller/ehpa/predict.go
+++ b/pkg/controller/ehpa/predict.go
@@ -3,6 +3,7 @@ package ehpa
 import (
 	"context"
 	"fmt"
+
 	autoscalingv2 "k8s.io/api/autoscaling/v2beta2"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"

--- a/pkg/prometheus-adapter/config_fetcher.go
+++ b/pkg/prometheus-adapter/config_fetcher.go
@@ -120,7 +120,7 @@ func (pc *PrometheusAdapterConfigFetcher) Reload(mapper meta.RESTMapper) {
 			if err != nil {
 				klog.Errorf("Got metricsDiscoveryConfig failed[%s] %v", pc.AdapterConfig, err)
 			} else {
-				err = FlushRules(*metricsDiscoveryConfig, mapper)
+				err = FlushRules(*metricsDiscoveryConfig, pc.RestMapper)
 				if err != nil {
 					klog.Errorf("Flush rules failed %v", err)
 				}

--- a/pkg/prometheus-adapter/config_fetcher.go
+++ b/pkg/prometheus-adapter/config_fetcher.go
@@ -95,7 +95,7 @@ func (paCm *PrometheusAdapterConfigChangedPredicate) Update(e event.UpdateEvent)
 }
 
 // if set promAdapterConfig, daemon reload by config fsnotify
-func (pc *PrometheusAdapterConfigFetcher) Reload(mapper meta.RESTMapper) {
+func (pc *PrometheusAdapterConfigFetcher) Reload() {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		klog.Error(err)

--- a/pkg/prometheus-adapter/config_fetcher.go
+++ b/pkg/prometheus-adapter/config_fetcher.go
@@ -57,7 +57,7 @@ func (pc *PrometheusAdapterConfigFetcher) Reconcile(ctx context.Context, req ctr
 		klog.Errorf("Got metricsDiscoveryConfig failed[%s] %v", pc.AdapterConfigMapName, err)
 	}
 
-	err = FlushRules(*cfg)
+	err = FlushRules(*cfg, pc.RestMapper)
 	if err != nil {
 		klog.Errorf("Flush rules failed %v", err)
 	}
@@ -95,7 +95,7 @@ func (paCm *PrometheusAdapterConfigChangedPredicate) Update(e event.UpdateEvent)
 }
 
 // if set promAdapterConfig, daemon reload by config fsnotify
-func (pc *PrometheusAdapterConfigFetcher) Reload() {
+func (pc *PrometheusAdapterConfigFetcher) Reload(mapper meta.RESTMapper) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		klog.Error(err)
@@ -120,7 +120,7 @@ func (pc *PrometheusAdapterConfigFetcher) Reload() {
 			if err != nil {
 				klog.Errorf("Got metricsDiscoveryConfig failed[%s] %v", pc.AdapterConfig, err)
 			} else {
-				err = FlushRules(*metricsDiscoveryConfig)
+				err = FlushRules(*metricsDiscoveryConfig, mapper)
 				if err != nil {
 					klog.Errorf("Flush rules failed %v", err)
 				}
@@ -134,16 +134,16 @@ func (pc *PrometheusAdapterConfigFetcher) Reload() {
 	}
 }
 
-func FlushRules(metricsDiscoveryConfig config.MetricsDiscoveryConfig) error {
-	err := ParsingResourceRules(metricsDiscoveryConfig)
+func FlushRules(metricsDiscoveryConfig config.MetricsDiscoveryConfig, mapper meta.RESTMapper) error {
+	err := ParsingResourceRules(metricsDiscoveryConfig, mapper)
 	if err != nil {
 		return err
 	}
-	err = ParsingRules(metricsDiscoveryConfig)
+	err = ParsingRules(metricsDiscoveryConfig, mapper)
 	if err != nil {
 		return err
 	}
-	err = ParsingExternalRules(metricsDiscoveryConfig)
+	err = ParsingExternalRules(metricsDiscoveryConfig, mapper)
 	if err != nil {
 		return err
 	}

--- a/pkg/prometheus-adapter/expression.go
+++ b/pkg/prometheus-adapter/expression.go
@@ -3,12 +3,12 @@ package prometheus_adapter
 import (
 	"bytes"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"regexp"
 	"strings"
 	"text/template"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/prometheus-adapter/pkg/config"
 	"sigs.k8s.io/prometheus-adapter/pkg/naming"
 )

--- a/pkg/querybuilder-providers/prometheus/builder.go
+++ b/pkg/querybuilder-providers/prometheus/builder.go
@@ -71,7 +71,7 @@ func (b *builder) workloadQuery(metric *metricquery.Metric) (query *metricquery.
 	}
 
 	if queryExpr == "" {
-		queryExpr, err = metricRule.QueryForSeries(metric.Workload.Namespace, append(mrs.ExtensionLabels, fmt.Sprintf("pod=~\"%s\"", utils.GetPodNameReg(metric.Workload.Name, metric.Workload.Kind))))
+		queryExpr, err = metricRule.QueryForSeries(metric.Workload.Namespace, utils.GetPodNameReg(metric.Workload.Name, metric.Workload.Kind), mrs.ExtensionLabels)
 	}
 	return promQuery(&metricquery.PrometheusQuery{Query: queryExpr}), err
 }
@@ -100,7 +100,7 @@ func (b *builder) nodeQuery(metric *metricquery.Metric) (query *metricquery.Quer
 	}
 
 	if queryExpr == "" {
-		queryExpr, err = metricRule.QueryForSeries("", append(mrs.ExtensionLabels, fmt.Sprintf("instance=~\"(%s)(:\\d+)?\"", metric.Node.Name)))
+		queryExpr, err = metricRule.QueryForSeries("", "", append(mrs.ExtensionLabels, fmt.Sprintf("instance=~\"(%s)(:\\d+)?\"", metric.Node.Name)))
 	}
 
 	return promQuery(&metricquery.PrometheusQuery{Query: queryExpr}), err
@@ -130,7 +130,7 @@ func (b *builder) containerQuery(metric *metricquery.Metric) (query *metricquery
 	}
 
 	if queryExpr == "" {
-		queryExpr, err = metricRule.QueryForSeries(metric.Container.Namespace, append(mrs.ExtensionLabels, []string{fmt.Sprintf("pod=~\"%s\"", utils.GetPodNameReg(metric.Container.WorkloadName, metric.Container.WorkloadKind)), fmt.Sprintf("container=\"%s\"", metric.Container.Name)}...))
+		queryExpr, err = metricRule.QueryForSeries(metric.Container.Namespace, utils.GetPodNameReg(metric.Container.WorkloadName, metric.Container.WorkloadKind), append(mrs.ExtensionLabels, fmt.Sprintf("container=\"%s\"", metric.Container.Name)))
 	}
 	return promQuery(&metricquery.PrometheusQuery{
 		Query: queryExpr,
@@ -161,7 +161,7 @@ func (b *builder) podQuery(metric *metricquery.Metric) (query *metricquery.Query
 	}
 
 	if queryExpr == "" {
-		queryExpr, err = metricRule.QueryForSeries(metric.Pod.Namespace, append(mrs.ExtensionLabels, fmt.Sprintf("pod=\"%s\"", metric.Pod.Name)))
+		queryExpr, err = metricRule.QueryForSeries(metric.Pod.Namespace, "", append(mrs.ExtensionLabels, fmt.Sprintf("pod=\"%s\"", metric.Pod.Name)))
 	}
 	return promQuery(&metricquery.PrometheusQuery{
 		Query: queryExpr,

--- a/site/content/zh/docs/Best Practices/effective-hpa-with-prometheus-adapter.md
+++ b/site/content/zh/docs/Best Practices/effective-hpa-with-prometheus-adapter.md
@@ -2,7 +2,7 @@
 title: "基于 Effective HPA 实现自定义指标的智能弹性实践"
 weight: 10
 description: >
-Effective HPA 的最佳实践.
+  Effective HPA 的最佳实践.
 ---
 
 Kubernetes HPA 支持了丰富的弹性扩展能力，Kubernetes 平台开发者部署服务实现自定义 Metric 的服务，Kubernetes 用户配置多项内置的资源指标或者自定义 Metric 指标实现自定义水平弹性。
@@ -179,24 +179,24 @@ craned通过读取prometheus-adapter配置，实现查询表达式模板的自�
 通过ConfigFile加载
 - prometheus-adapter-config=/prometheus-adapter.cfg
 
-全局扩展标签
+全局扩展标签 
 
-通过该参数可实现查询表达式labelMatchers的全局扩展，实现指标的分类，多个标签以","分隔
+ 通过该参数可实现查询表达式labelMatchers的全局扩展，实现指标的分类，多个标签以","分隔
 
 - prometheus-adapter-extension-labels=cluster="prod",container!=""
 
 ```yaml
 
-spec:
-  containers:
-    - args:
+    spec:
+      containers:
+      - args:
         - --prometheus-adapter-configmap-namespace=monitoring
         - --prometheus-adapter-configmap-name=prometheus-adapter-config
         - --prometheus-adapter-configmap-key=config
         - --prometheus-adapter-extension-labels=cluster="prod",container!=""
 ...
-command:
-  - /craned
+        command:
+        - /craned
 
 ```
 
@@ -226,16 +226,16 @@ spec:
         app: sample-app
     spec:
       containers:
-        - image: luxas/autoscale-demo:v0.1.2
-          name: metrics-provider
-          resources:
-            limits:
-              cpu: 500m
-            requests:
-              cpu: 200m
-          ports:
-            - name: http
-              containerPort: 8080
+      - image: luxas/autoscale-demo:v0.1.2
+        name: metrics-provider
+        resources:
+          limits:
+            cpu: 500m
+          requests:
+            cpu: 200m
+        ports:
+        - name: http
+          containerPort: 8080
 ```
 
 <summary>sample-app.service.yaml</summary>
@@ -249,10 +249,10 @@ metadata:
   name: sample-app
 spec:
   ports:
-    - name: http
-      port: 80
-      protocol: TCP
-      targetPort: 8080
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
   selector:
     app: sample-app
   type: ClusterIP
@@ -282,22 +282,22 @@ kubectl edit configmap -n crane-system prometheus-server
 ```yaml
     - job_name: sample-app
       kubernetes_sd_configs:
-        - role: pod
+      - role: pod
       relabel_configs:
-        - action: keep
-          regex: default;sample-app-(.+)
-          source_labels:
-            - __meta_kubernetes_namespace
-            - __meta_kubernetes_pod_name
-        - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
-        - action: replace
-          source_labels:
-            - __meta_kubernetes_namespace
-          target_label: namespace
-        - source_labels: [__meta_kubernetes_pod_name]
-          action: replace
-          target_label: pod
+      - action: keep
+        regex: default;sample-app-(.+)
+        source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_name
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        source_labels:
+        - __meta_kubernetes_namespace
+        target_label: namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
 ```
 
 此时，您可以在 Prometheus 查询 psql：sum(rate(http_requests_total[5m])) by (pod)
@@ -364,19 +364,19 @@ spec:
   scaleStrategy: Auto   # ScaleStrategy indicate the strategy to scaling target, value can be "Auto" and "Manual".
   # Metrics contains the specifications for which to use to calculate the desired replica count.
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 50
-    - type: Pods
-      pods:
-        metric:
-          name: http_requests
-        target:
-          type: AverageValue
-          averageValue: 500m
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+  - type: Pods
+    pods:
+      metric:
+        name: http_requests
+      target:
+        type: AverageValue
+        averageValue: 500m
   # Prediction defines configurations for predict resources.
   # If unspecified, defaults don't enable prediction.
   prediction:
@@ -395,13 +395,13 @@ kubectl create -f sample-app-hpa.yaml
 通过Prometheus-adapter增加模板配置
 ```yaml
     rules:
-      - seriesQuery: 'http_requests_total{pod!=""}'
-        name:
-          matches: "(.*)_total$"
-          as: "${1}"
-        resources:
-          namespaced: true
-        metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)'
+    - seriesQuery: 'http_requests_total{pod!=""}'
+      name:
+        matches: "(.*)_total$"
+        as: "${1}"
+      resources:
+        namespaced: true
+      metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)'
 ```
 
 查看 TimeSeriesPrediction 状态，如果应用运行时间较短，可能会无法预测：
@@ -489,29 +489,29 @@ metadata:
 spec:
   maxReplicas: 10
   metrics:
-    - pods:
-        metric:
-          name: http_requests
-        target:
-          averageValue: 500m
-          type: AverageValue
-      type: Pods
-    - pods:
-        metric:
-          name: pods.http_requests
-          selector:
-            matchLabels:
-              autoscaling.crane.io/effective-hpa-uid: 1322c5ac-a1c6-4c71-98d6-e85d07b22da0
-        target:
-          averageValue: 500m
-          type: AverageValue
-      type: Pods
-    - resource:
-        name: cpu
-        target:
-          averageUtilization: 50
-          type: Utilization
-      type: Resource
+  - pods:
+      metric:
+        name: http_requests
+      target:
+        averageValue: 500m
+        type: AverageValue
+    type: Pods
+  - pods:
+      metric:
+        name: pods.http_requests
+        selector:
+          matchLabels:
+            autoscaling.crane.io/effective-hpa-uid: 1322c5ac-a1c6-4c71-98d6-e85d07b22da0
+      target:
+        averageValue: 500m
+        type: AverageValue
+    type: Pods
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 50
+        type: Utilization
+    type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1

--- a/site/content/zh/docs/Best Practices/effective-hpa-with-prometheus-adapter.md
+++ b/site/content/zh/docs/Best Practices/effective-hpa-with-prometheus-adapter.md
@@ -2,7 +2,7 @@
 title: "基于 Effective HPA 实现自定义指标的智能弹性实践"
 weight: 10
 description: >
-  Effective HPA 的最佳实践.
+Effective HPA 的最佳实践.
 ---
 
 Kubernetes HPA 支持了丰富的弹性扩展能力，Kubernetes 平台开发者部署服务实现自定义 Metric 的服务，Kubernetes 用户配置多项内置的资源指标或者自定义 Metric 指标实现自定义水平弹性。
@@ -179,24 +179,24 @@ craned通过读取prometheus-adapter配置，实现查询表达式模板的自�
 通过ConfigFile加载
 - prometheus-adapter-config=/prometheus-adapter.cfg
 
-全局扩展标签 
+全局扩展标签
 
- 通过该参数可实现查询表达式labelMatchers的全局扩展，实现指标的分类，多个标签以","分隔
+通过该参数可实现查询表达式labelMatchers的全局扩展，实现指标的分类，多个标签以","分隔
 
-- prometheus-adapter-extension-labels=cluster="prod",container!="" 
+- prometheus-adapter-extension-labels=cluster="prod",container!=""
 
 ```yaml
 
-    spec:
-      containers:
-      - args:
+spec:
+  containers:
+    - args:
         - --prometheus-adapter-configmap-namespace=monitoring
         - --prometheus-adapter-configmap-name=prometheus-adapter-config
-        - --prometheus-adapter-configmap-key=config.yaml
+        - --prometheus-adapter-configmap-key=config
         - --prometheus-adapter-extension-labels=cluster="prod",container!=""
 ...
-        command:
-        - /craned
+command:
+  - /craned
 
 ```
 
@@ -226,16 +226,16 @@ spec:
         app: sample-app
     spec:
       containers:
-      - image: luxas/autoscale-demo:v0.1.2
-        name: metrics-provider
-        resources:
-          limits:
-            cpu: 500m
-          requests:
-            cpu: 200m
-        ports:
-        - name: http
-          containerPort: 8080
+        - image: luxas/autoscale-demo:v0.1.2
+          name: metrics-provider
+          resources:
+            limits:
+              cpu: 500m
+            requests:
+              cpu: 200m
+          ports:
+            - name: http
+              containerPort: 8080
 ```
 
 <summary>sample-app.service.yaml</summary>
@@ -249,10 +249,10 @@ metadata:
   name: sample-app
 spec:
   ports:
-  - name: http
-    port: 80
-    protocol: TCP
-    targetPort: 8080
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
   selector:
     app: sample-app
   type: ClusterIP
@@ -282,22 +282,22 @@ kubectl edit configmap -n crane-system prometheus-server
 ```yaml
     - job_name: sample-app
       kubernetes_sd_configs:
-      - role: pod
+        - role: pod
       relabel_configs:
-      - action: keep
-        regex: default;sample-app-(.+)
-        source_labels:
-        - __meta_kubernetes_namespace
-        - __meta_kubernetes_pod_name
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - action: replace
-        source_labels:
-        - __meta_kubernetes_namespace
-        target_label: namespace
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: pod
+        - action: keep
+          regex: default;sample-app-(.+)
+          source_labels:
+            - __meta_kubernetes_namespace
+            - __meta_kubernetes_pod_name
+        - action: labelmap
+          regex: __meta_kubernetes_pod_label_(.+)
+        - action: replace
+          source_labels:
+            - __meta_kubernetes_namespace
+          target_label: namespace
+        - source_labels: [__meta_kubernetes_pod_name]
+          action: replace
+          target_label: pod
 ```
 
 此时，您可以在 Prometheus 查询 psql：sum(rate(http_requests_total[5m])) by (pod)
@@ -364,19 +364,19 @@ spec:
   scaleStrategy: Auto   # ScaleStrategy indicate the strategy to scaling target, value can be "Auto" and "Manual".
   # Metrics contains the specifications for which to use to calculate the desired replica count.
   metrics:
-  - type: Resource
-    resource:
-      name: cpu
-      target:
-        type: Utilization
-        averageUtilization: 50
-  - type: Pods
-    pods:
-      metric:
-        name: http_requests
-      target:
-        type: AverageValue
-        averageValue: 500m
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+    - type: Pods
+      pods:
+        metric:
+          name: http_requests
+        target:
+          type: AverageValue
+          averageValue: 500m
   # Prediction defines configurations for predict resources.
   # If unspecified, defaults don't enable prediction.
   prediction:
@@ -395,13 +395,13 @@ kubectl create -f sample-app-hpa.yaml
 通过Prometheus-adapter增加模板配置
 ```yaml
     rules:
-    - seriesQuery: 'http_requests_total{pod!=""}'
-      name:
-        matches: "(.*)_total$"
-        as: "${1}"
-      resources:
-        namespaced: true
-      metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)'
+      - seriesQuery: 'http_requests_total{pod!=""}'
+        name:
+          matches: "(.*)_total$"
+          as: "${1}"
+        resources:
+          namespaced: true
+        metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)'
 ```
 
 查看 TimeSeriesPrediction 状态，如果应用运行时间较短，可能会无法预测：
@@ -489,29 +489,29 @@ metadata:
 spec:
   maxReplicas: 10
   metrics:
-  - pods:
-      metric:
-        name: http_requests
-      target:
-        averageValue: 500m
-        type: AverageValue
-    type: Pods
-  - pods:
-      metric:
-        name: pods.http_requests
-        selector:
-          matchLabels:
-            autoscaling.crane.io/effective-hpa-uid: 1322c5ac-a1c6-4c71-98d6-e85d07b22da0
-      target:
-        averageValue: 500m
-        type: AverageValue
-    type: Pods
-  - resource:
-      name: cpu
-      target:
-        averageUtilization: 50
-        type: Utilization
-    type: Resource
+    - pods:
+        metric:
+          name: http_requests
+        target:
+          averageValue: 500m
+          type: AverageValue
+      type: Pods
+    - pods:
+        metric:
+          name: pods.http_requests
+          selector:
+            matchLabels:
+              autoscaling.crane.io/effective-hpa-uid: 1322c5ac-a1c6-4c71-98d6-e85d07b22da0
+        target:
+          averageValue: 500m
+          type: AverageValue
+      type: Pods
+    - resource:
+        name: cpu
+        target:
+          averageUtilization: 50
+          type: Utilization
+      type: Resource
   minReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1


### PR DESCRIPTION
#### What type of PR is this?
add support for prom-adapter overrides 
 
for example:
```yaml
    - seriesQuery: 'metric_example'
      resources:
        overrides:
          pod_namespace: {resource: "namespace"}
          pod_name: {resource: "pod"}
        namespaced: true
      metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)'

sum(metric_example{namespace="test",pod=~"test-.*"}) 

to 
sum(metric_example{pod_namespace="test",pod_name=~"test-.*"}) 

```
#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

