### PR TITLE
if one of the rules is not declared, no error will be thrown

### DIFF
--- a/pkg/prometheus-adapter/expression.go
+++ b/pkg/prometheus-adapter/expression.go
@@ -58,15 +58,15 @@ func GetMetricRules() *MetricRules {
 
 // ParsingResourceRules from config.MetricsDiscoveryConfig
 func ParsingResourceRules(mc config.MetricsDiscoveryConfig) (err error) {
-	metricRules.MetricRulesResource, err = GetMetricRulesFromResourceRules(*mc.ResourceRules)
+	if mc.ResourceRules != nil {
+		metricRules.MetricRulesResource, err = GetMetricRulesFromResourceRules(*mc.ResourceRules)
+	}
 	return err
 }
 
 // ParsingRules from config.MetricsDiscoveryConfig
 func ParsingRules(mc config.MetricsDiscoveryConfig) (err error) {
-	if mc.Rules == nil {
-		return fmt.Errorf("Rules is nil")
-	} else {
+	if mc.Rules != nil {
 		metricRules.MetricRulesCustomer, err = GetMetricRulesFromDiscoveryRule(mc.Rules)
 	}
 	return err
@@ -74,9 +74,7 @@ func ParsingRules(mc config.MetricsDiscoveryConfig) (err error) {
 
 // ParsingExternalRules from config.MetricsDiscoveryConfig
 func ParsingExternalRules(mc config.MetricsDiscoveryConfig) (err error) {
-	if mc.ExternalRules == nil {
-		return fmt.Errorf("ExternalRules is nil")
-	} else {
+	if mc.ExternalRules != nil {
 		metricRules.MetricRulesExternal, err = GetMetricRulesFromDiscoveryRule(mc.ExternalRules)
 	}
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
optimzation

#### What this PR does / why we need it:

For example, if the user does not need the indicators of the external rule, there is no necessary to declare it. That is correct so no need to throw error in this case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

