### PR TITLE
fix default histogram MaxValue of makeMemConfig

### DIFF
--- a/pkg/recommendation/recommender/resource/recommend.go
+++ b/pkg/recommendation/recommender/resource/recommend.go
@@ -77,7 +77,7 @@ func (rr *ResourceRecommender) makeMemConfig() *config.Config {
 			Histogram: predictionapi.HistogramConfig{
 				HalfLife:   "48h",
 				BucketSize: "104857600",
-				MaxValue:   "104857600000",
+				MaxValue:   "314572800000",
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
fix

#### What this PR does / why we need it:
adjust the percentile recommended memory maximum value from 100Gi to 300Gi to to support large memory workload


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

