### PR TITLE
update nginx.conf

### DIFF
--- a/deploy/craned/deployment.yaml
+++ b/deploy/craned/deployment.yaml
@@ -191,7 +191,6 @@ data:
         add_header Cache-Control "must-revalidate";
         add_header Cache-Control "max-age=300";
         add_header ETag "1.90.0-rc.0";
-        add_header Access-Control-Allow-Origin *;
         listen 9090;
         listen [::]:9090;
         location / {
@@ -200,6 +199,7 @@ data:
             try_files $uri $uri/ /index.html;
         }
         location /grafana {
+            add_header Access-Control-Allow-Origin *;
             set $upstream_grafana grafana.crane-system.svc.cluster.local;
             proxy_pass http://$upstream_grafana:8082;
             rewrite /grafana/(.*) /$1 break;


### PR DESCRIPTION
Only add CORS header to grafana section in nginx.conf, otherwise it may encounter CORS error when using dashboard to manage multi clusters. 

<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
Update nginx.conf

#### What this PR does / why we need it:
When using dashboard to manage multi clusters, if using the old nginx config will encounter CORS failure when accessing '/api/v1/recommendation' and other URLs, except those relative about grafana.

In #551 , @lbbniu delete CORS header from global section. But in this case, it will enconter CORS error when accessing grafana urls.
<img width="1437" alt="image" src="https://user-images.githubusercontent.com/49898234/212257051-65f00291-cc12-47a4-bf17-6897e87db6b4.png">

So, the solution is delete 'add_header Access-Control-Allow-Origin' from global section, and add it to grafana section:
![image](https://user-images.githubusercontent.com/49898234/212257534-bc74afb2-156e-4a4d-bfe5-ed3193ebf661.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #551 


