### PR TITLE
delete recommendation belong to recommendationrule if target oject not found

### DIFF
--- a/pkg/utils/recommend.go
+++ b/pkg/utils/recommend.go
@@ -5,6 +5,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
+
+	analysisv1alpha1 "github.com/gocrane/api/analysis/v1alpha1"
 )
 
 func GetGroupVersionResource(discoveryClient discovery.DiscoveryInterface, apiVersion string, kind string) (*schema.GroupVersionResource, error) {
@@ -30,4 +32,13 @@ func GetGroupVersionResource(discoveryClient discovery.DiscoveryInterface, apiVe
 	}
 	gvr := gv.WithResource(resName)
 	return &gvr, nil
+}
+
+func IsRecommendationControlledByRule(hpa *analysisv1alpha1.Recommendation) bool {
+	for _, ownerReference := range hpa.OwnerReferences {
+		if ownerReference.Kind == "RecommendationRule" {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION


#### What type of PR is this?
optimize

#### What this PR does / why we need it:

if we deploy recommendationrule to cover all deployment/statefulset like example, craned will create correspond recommendation for all deployment/statefulset. 
If we delete some workloads (required for testing), the recommendation will not be deleted. After a period of time, there will be many unavailable recommedations in the cluster.

so this PR optimizes the issue. if recommendation is created by recommendationrule and its target object has been deleted, delete correspond recommendation.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

