### PR TITLE
observe metrics in recommendation controller

### DIFF
--- a/cmd/craned/app/manager.go
+++ b/cmd/craned/app/manager.go
@@ -368,11 +368,12 @@ func initControllers(oomRecorder oom.Recorder, mgr ctrl.Manager, opts *options.O
 		}
 
 		if err := (&recommendationctrl.RecommendationController{
-			Client:      mgr.GetClient(),
-			Scheme:      mgr.GetScheme(),
-			RestMapper:  mgr.GetRESTMapper(),
-			ScaleClient: scaleClient,
-			Recorder:    mgr.GetEventRecorderFor("recommendation-controller"),
+			Client:         mgr.GetClient(),
+			Scheme:         mgr.GetScheme(),
+			RestMapper:     mgr.GetRESTMapper(),
+			RecommenderMgr: recommenderMgr,
+			ScaleClient:    scaleClient,
+			Recorder:       mgr.GetEventRecorderFor("recommendation-controller"),
 		}).SetupWithManager(mgr); err != nil {
 			klog.Exit(err, "unable to create controller", "controller", "RecommendationController")
 		}

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/kubelet v0.22.3
 	k8s.io/kubernetes v1.22.3
 	k8s.io/metrics v0.22.3
+	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a
 	sigs.k8s.io/controller-runtime v0.10.2
 	sigs.k8s.io/custom-metrics-apiserver v1.22.0
 	sigs.k8s.io/prometheus-adapter v0.9.0
@@ -163,7 +164,6 @@ require (
 	k8s.io/component-helpers v0.22.3 // indirect
 	k8s.io/kube-scheduler v0.0.0 // indirect
 	k8s.io/mount-utils v0.22.3 // indirect
-	k8s.io/utils v0.0.0-20210819203725-bdf08cb9a70a // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )

--- a/pkg/controller/recommendation/recommendation_rule_controller.go
+++ b/pkg/controller/recommendation/recommendation_rule_controller.go
@@ -363,7 +363,7 @@ func (c *RecommendationRuleController) executeMission(ctx context.Context, wg *s
 			recommendation = c.CreateRecommendationObject(recommendationRule, mission.TargetRef, id, mission.RecommenderRef.Name)
 		}
 
-		r, err := c.RecommenderMgr.GetRecommender(mission.RecommenderRef.Name, *recommendationRule)
+		r, err := c.RecommenderMgr.GetRecommenderWithRule(mission.RecommenderRef.Name, *recommendationRule)
 		if err != nil {
 			mission.Message = fmt.Sprintf("get recommender %s failed, %v", mission.RecommenderRef.Name, err)
 			return

--- a/pkg/recommendation/framework/context.go
+++ b/pkg/recommendation/framework/context.go
@@ -87,6 +87,14 @@ func NewRecommendationContext(context context.Context, identity ObjectIdentity, 
 	}
 }
 
+func NewRecommendationContextForObserve(recommendation *v1alpha1.Recommendation, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter) RecommendationContext {
+	return RecommendationContext{
+		Recommendation: recommendation,
+		RestMapper:     restMapper,
+		ScaleClient:    scaleClient,
+	}
+}
+
 func (ctx RecommendationContext) String() string {
 	return fmt.Sprintf("RecommendationRule(%s) Target(%s/%s)", ctx.RecommendationRule.Name, ctx.Object.GetNamespace(), ctx.Object.GetName())
 }

--- a/pkg/recommendation/manager.go
+++ b/pkg/recommendation/manager.go
@@ -22,7 +22,9 @@ import (
 
 type RecommenderManager interface {
 	// GetRecommender return a registered recommender
-	GetRecommender(recommenderName string, recommendationRule analysisv1alph1.RecommendationRule) (recommender.Recommender, error)
+	GetRecommender(recommenderName string) (recommender.Recommender, error)
+	// GetRecommenderWithRule return a registered recommender, its config merged with recommendationRule
+	GetRecommenderWithRule(recommenderName string, recommendationRule analysisv1alph1.RecommendationRule) (recommender.Recommender, error)
 }
 
 func NewRecommenderManager(recommendationConfiguration string, oomRecorder oom.Recorder, realtimeDataSources map[providers.DataSourceType]providers.RealTime, historyDataSources map[providers.DataSourceType]providers.History) RecommenderManager {
@@ -53,7 +55,11 @@ type manager struct {
 	oomRecorder        oom.Recorder
 }
 
-func (m *manager) GetRecommender(recommenderName string, recommendationRule analysisv1alph1.RecommendationRule) (recommender.Recommender, error) {
+func (m *manager) GetRecommender(recommenderName string) (recommender.Recommender, error) {
+	return m.GetRecommenderWithRule(recommenderName, analysisv1alph1.RecommendationRule{})
+}
+
+func (m *manager) GetRecommenderWithRule(recommenderName string, recommendationRule analysisv1alph1.RecommendationRule) (recommender.Recommender, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/pkg/recommendation/recommender/resource/observe.go
+++ b/pkg/recommendation/recommender/resource/observe.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/gocrane/crane/pkg/metrics"
 	"github.com/gocrane/crane/pkg/recommendation/framework"
+	"github.com/gocrane/crane/pkg/utils"
 )
 
 // Observe enhance the observability.
@@ -31,15 +33,20 @@ func (rr *ResourceRecommender) Observe(ctx *framework.RecommendationContext) err
 		return err
 	}
 
+	resourceNameList := []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory}
 	for _, container := range newPodTemplate.Spec.Containers {
-		rr.recordResourceRecommendation(ctx, container.Name, v1.ResourceCPU, container.Resources.Requests[v1.ResourceCPU])
-		rr.recordResourceRecommendation(ctx, container.Name, v1.ResourceMemory, container.Resources.Requests[v1.ResourceMemory])
+		for _, resourceName := range resourceNameList {
+			err = rr.recordResourceRecommendation(ctx, container.Name, resourceName, container.Resources.Requests[resourceName])
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return nil
 }
 
-func (rr *ResourceRecommender) recordResourceRecommendation(ctx *framework.RecommendationContext, containerName string, resName v1.ResourceName, quantity resource.Quantity) {
+func (rr *ResourceRecommender) recordResourceRecommendation(ctx *framework.RecommendationContext, containerName string, resName v1.ResourceName, quantity resource.Quantity) error {
 	labels := map[string]string{
 		"apiversion": ctx.Recommendation.Spec.TargetRef.APIVersion,
 		"owner_kind": ctx.Recommendation.Spec.TargetRef.Kind,
@@ -49,7 +56,11 @@ func (rr *ResourceRecommender) recordResourceRecommendation(ctx *framework.Recom
 		"resource":   resName.String(),
 	}
 
-	labels["owner_replicas"] = fmt.Sprintf("%d", len(ctx.Pods))
+	scale, _, err := utils.GetScaleFromObjectReference(context.TODO(), ctx.RestMapper, ctx.ScaleClient, ctx.Recommendation.Spec.TargetRef)
+	if err != nil {
+		return err
+	}
+	labels["owner_replicas"] = fmt.Sprintf("%d", scale.Spec.Replicas)
 
 	switch resName {
 	case v1.ResourceCPU:
@@ -57,4 +68,6 @@ func (rr *ResourceRecommender) recordResourceRecommendation(ctx *framework.Recom
 	case v1.ResourceMemory:
 		metrics.ResourceRecommendation.With(labels).Set(float64(quantity.Value()))
 	}
+
+	return nil
 }

--- a/pkg/utils/scale.go
+++ b/pkg/utils/scale.go
@@ -44,6 +44,15 @@ func GetScale(ctx context.Context, restMapper meta.RESTMapper, scaleClient scale
 	return nil, nil, fmt.Errorf("unrecognized resource: %+v", errs)
 }
 
+func GetScaleFromObjectReference(ctx context.Context, restMapper meta.RESTMapper, scaleClient scale.ScalesGetter, ref v1.ObjectReference) (*autoscalingapiv1.Scale, *meta.RESTMapping, error) {
+	newRef := autoscalingv2.CrossVersionObjectReference{
+		APIVersion: ref.APIVersion,
+		Kind:       ref.Kind,
+		Name:       ref.Name,
+	}
+	return GetScale(ctx, restMapper, scaleClient, ref.Namespace, newRef)
+}
+
 func GetPodsFromScale(kubeClient client.Client, scale *autoscalingapiv1.Scale) ([]v1.Pod, error) {
 	selector, err := labels.ConvertSelectorToLabelsMap(scale.Status.Selector)
 	if err != nil {


### PR DESCRIPTION

#### What type of PR is this?
optimize

#### What this PR does / why we need it:
Currutly recommendation metrics will lost after restart craned because the metrics is created in the progress of calculation of recommend.
If we observe recommendation status in recommedation controller, that can avoid this issue. 

#### Which issue(s) this PR fixes:

Fixes #672

#### Special notes for your reviewer:

