### PR TITLE
add maxConcurrentReconciles flag for tsp controller

### DIFF
--- a/cmd/craned/app/manager.go
+++ b/cmd/craned/app/manager.go
@@ -347,7 +347,7 @@ func initControllers(oomRecorder oom.Recorder, mgr ctrl.Manager, opts *options.O
 			predictorMgr,
 			targetSelectorFetcher,
 		)
-		if err := tspController.SetupWithManager(mgr); err != nil {
+		if err := tspController.SetupWithManager(mgr, opts.TimeSeriesPredictionMaxConcurrentReconciles); err != nil {
 			klog.Exit(err, "unable to create controller", "controller", "TspController")
 		}
 	}

--- a/cmd/craned/app/options/options.go
+++ b/cmd/craned/app/options/options.go
@@ -58,6 +58,9 @@ type Options struct {
 
 	// OOMRecordMaxNumber is the max number for oom record
 	OOMRecordMaxNumber int
+
+	// TimeSeriesPredictionMaxConcurrentReconciles is the max concurrent reconciles for TimeSeriesPrediction controller
+	TimeSeriesPredictionMaxConcurrentReconciles int
 }
 
 // NewOptions builds an empty options.
@@ -127,5 +130,5 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringSliceVar(&o.EhpaControllerConfig.PropagationConfig.Labels, "ehpa-propagation-labels", []string{}, "propagate labels whose key is complete matching to hpa")
 	flags.StringSliceVar(&o.EhpaControllerConfig.PropagationConfig.Annotations, "ehpa-propagation-annotations", []string{}, "propagate annotations whose key is complete matching to hpa")
 	flags.IntVar(&o.OOMRecordMaxNumber, "oom-record-max-number", 10000, "Max number for oom records to store in configmap")
-
+	flags.IntVar(&o.TimeSeriesPredictionMaxConcurrentReconciles, "time-series-prediction-max-concurrent-reconciles", 10, "Max concurrent reconciles for TimeSeriesPrediction controller")
 }

--- a/pkg/controller/timeseriesprediction/time_series_prediction_controller.go
+++ b/pkg/controller/timeseriesprediction/time_series_prediction_controller.go
@@ -16,6 +16,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	predictionapi "github.com/gocrane/api/prediction/v1alpha1"
@@ -90,8 +91,9 @@ func (tc *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Res
 }
 
 // SetupWithManager creates a controller and register to controller manager.
-func (tc *Controller) SetupWithManager(mgr ctrl.Manager) error {
+func (tc *Controller) SetupWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 		For(&predictionapi.TimeSeriesPrediction{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(tc)
 }


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it:
Currently tsp controller reconcile a goroutine to query data from prometheus. Sometimes query take long time and need to increase the value of goroutines to run the reconcile.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

