### PR TITLE
feat: Support trigger a recommendation manually

### DIFF
--- a/cmd/craned/app/manager.go
+++ b/cmd/craned/app/manager.go
@@ -391,6 +391,17 @@ func initControllers(oomRecorder oom.Recorder, mgr ctrl.Manager, opts *options.O
 		}).SetupWithManager(mgr); err != nil {
 			klog.Exit(err, "unable to create controller", "controller", "RecommendationRuleController")
 		}
+
+		if err := (&recommendationctrl.RecommendationTriggerController{
+			Client:         mgr.GetClient(),
+			RecommenderMgr: recommenderMgr,
+			ScaleClient:    scaleClient,
+			Provider:       historyDataSource,
+			PredictorMgr:   predictorMgr,
+			Recorder:       mgr.GetEventRecorderFor("recommendation-trigger-controller"),
+		}).SetupWithManager(mgr); err != nil {
+			klog.Exit(err, "unable to create controller", "controller", "RecommendationTriggerController")
+		}
 	}
 
 	// CnpController

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/evanphx/json-patch v4.11.0+incompatible
 	github.com/go-echarts/go-echarts/v2 v2.2.4
-	github.com/gocrane/api v0.0.0-20230117025609-8b3a495647d9
+	github.com/gocrane/api v0.9.1-0.20230307114903-ce6fcd9a2eaf
 	github.com/google/cadvisor v0.39.2
 	github.com/jaypipes/ghw v0.9.0
 	github.com/mjibson/go-dsp v0.0.0-20180508042940-11479a337f12
@@ -52,10 +52,12 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
@@ -74,6 +76,7 @@ require (
 	github.com/emicklei/go-restful v2.15.0+incompatible // indirect
 	github.com/emicklei/go-restful-swagger12 v0.0.0-20201014110547-68ccff494617 // indirect
 	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
+	github.com/evanphx/json-patch/v5 v5.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
@@ -118,6 +121,7 @@ require (
 	github.com/opencontainers/runc v1.0.2 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.8.2 // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -165,6 +169,7 @@ require (
 	k8s.io/kube-scheduler v0.0.0 // indirect
 	k8s.io/mount-utils v0.22.3 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22 // indirect
+	sigs.k8s.io/kind v0.11.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -258,6 +260,8 @@ github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdR
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v4.11.0+incompatible h1:glyUF9yIYtMHzn8xaKw5rMhdWcwsYV8dZHIq5567/xs=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.2.0 h1:8ozOH5xxoMYDt5/u+yMTsVXydVCbTORFnOOoq2lumco=
+github.com/evanphx/json-patch/v5 v5.2.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -350,6 +354,8 @@ github.com/gobwas/ws v1.1.0-rc.5 h1:QOAag7FoBaBYYHRqzqkhhd8fq5RTubvI4v3Ft/gDVVQ=
 github.com/gobwas/ws v1.1.0-rc.5/go.mod h1:nzvNcVha5eUziGrbxFCo6qFIojQHjJV5cLYIbezhfL0=
 github.com/gocrane/api v0.0.0-20230117025609-8b3a495647d9 h1:3R06LMq6zl+LyYBlmoVPXjY2E3XtsMqZ7WPBA+BMa/M=
 github.com/gocrane/api v0.0.0-20230117025609-8b3a495647d9/go.mod h1:GxI+t9AW8+NsHkz2JkPBIJN//9eLUjTZl1ScYAbXMbk=
+github.com/gocrane/api v0.9.1-0.20230307114903-ce6fcd9a2eaf h1:HwjISCuAIPI/ZqzLDmw5WL1Yz0vjshzXt/3vNXEsCJs=
+github.com/gocrane/api v0.9.1-0.20230307114903-ce6fcd9a2eaf/go.mod h1:GxI+t9AW8+NsHkz2JkPBIJN//9eLUjTZl1ScYAbXMbk=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -716,6 +722,8 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -814,6 +822,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
@@ -1506,6 +1515,8 @@ sigs.k8s.io/controller-runtime v0.10.2 h1:jW8qiY+yMnnPx6O9hu63tgcwaKzd1yLYui+mpv
 sigs.k8s.io/controller-runtime v0.10.2/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/custom-metrics-apiserver v1.22.0 h1:nRrRRCq46m3y6lCp/6rfptPjX0eGsF88s66vt9TWgac=
 sigs.k8s.io/custom-metrics-apiserver v1.22.0/go.mod h1:QST5+Nu7RXcDVbg19K+0UT+2QMxnw+FSB6q7sv3yDUw=
+sigs.k8s.io/kind v0.11.1 h1:pVzOkhUwMBrCB0Q/WllQDO3v14Y+o2V0tFgjTqIUjwA=
+sigs.k8s.io/kind v0.11.1/go.mod h1:fRpgVhtqAWrtLB9ED7zQahUimpUXuG/iHT88xYqEGIA=
 sigs.k8s.io/kustomize/api v0.8.11/go.mod h1:a77Ls36JdfCWojpUqR6m60pdGY1AYFix4AH83nJtY1g=
 sigs.k8s.io/kustomize/cmd/config v0.9.13/go.mod h1:7547FLF8W/lTaDf0BDqFTbZxM9zqwEJqCKN9sSR0xSs=
 sigs.k8s.io/kustomize/kustomize/v4 v4.2.0/go.mod h1:MOkR6fmhwG7hEDRXBYELTi5GSFcLwfqwzTRHW3kv5go=

--- a/pkg/controller/ehpa/hpa_observer_controller.go
+++ b/pkg/controller/ehpa/hpa_observer_controller.go
@@ -51,12 +51,7 @@ func (c *HPAObserverController) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	// Watch for changes to HPA
-	err = controller.Watch(&source.Kind{Type: &autoscalingv2.HorizontalPodAutoscaler{}}, &hpaEventHandler{
+	return controller.Watch(&source.Kind{Type: &autoscalingv2.HorizontalPodAutoscaler{}}, &hpaEventHandler{
 		enqueueHandler: handler.EnqueueRequestForObject{},
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pkg/controller/recommendation/recommendation_controller.go
+++ b/pkg/controller/recommendation/recommendation_controller.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	analysisv1alph1 "github.com/gocrane/api/analysis/v1alpha1"
+	analysisv1alpha1 "github.com/gocrane/api/analysis/v1alpha1"
 	predictormgr "github.com/gocrane/crane/pkg/predictor"
 	"github.com/gocrane/crane/pkg/providers"
 	recommender "github.com/gocrane/crane/pkg/recommendation"
@@ -27,7 +27,7 @@ import (
 // RecommendationController is responsible for reconcile Recommendation
 type RecommendationController struct {
 	client.Client
-	ConfigSet      *analysisv1alph1.ConfigSet
+	ConfigSet      *analysisv1alpha1.ConfigSet
 	Scheme         *runtime.Scheme
 	Recorder       record.EventRecorder
 	RestMapper     meta.RESTMapper
@@ -40,7 +40,7 @@ type RecommendationController struct {
 func (c *RecommendationController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	klog.V(4).Infof("Got Recommendation %s", req.NamespacedName)
 
-	recommendation := &analysisv1alph1.Recommendation{}
+	recommendation := &analysisv1alpha1.Recommendation{}
 	err := c.Client.Get(ctx, req.NamespacedName, recommendation)
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
@@ -87,7 +87,7 @@ func (c *RecommendationController) Reconcile(ctx context.Context, req ctrl.Reque
 	return ctrl.Result{}, nil
 }
 
-func (c *RecommendationController) UpdateStatus(ctx context.Context, recommendation *analysisv1alph1.Recommendation, newStatus *analysisv1alph1.RecommendationStatus) error {
+func (c *RecommendationController) UpdateStatus(ctx context.Context, recommendation *analysisv1alpha1.Recommendation, newStatus *analysisv1alpha1.RecommendationStatus) error {
 	if !equality.Semantic.DeepEqual(&recommendation.Status, newStatus) {
 		recommendation.Status = *newStatus
 		timeNow := metav1.Now()
@@ -108,11 +108,11 @@ func (c *RecommendationController) UpdateStatus(ctx context.Context, recommendat
 
 func (c *RecommendationController) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&analysisv1alph1.Recommendation{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&analysisv1alpha1.Recommendation{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Complete(c)
 }
 
-func setReadyCondition(status *analysisv1alph1.RecommendationStatus, conditionStatus metav1.ConditionStatus, reason string, message string) {
+func setReadyCondition(status *analysisv1alpha1.RecommendationStatus, conditionStatus metav1.ConditionStatus, reason string, message string) {
 	for i := range status.Conditions {
 		if status.Conditions[i].Type == "Ready" {
 			status.Conditions[i].Status = conditionStatus

--- a/pkg/controller/recommendation/recommendation_trigger_controller.go
+++ b/pkg/controller/recommendation/recommendation_trigger_controller.go
@@ -1,0 +1,160 @@
+package recommendation
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/scale"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	analysisv1alpha1 "github.com/gocrane/api/analysis/v1alpha1"
+
+	predictormgr "github.com/gocrane/crane/pkg/predictor"
+	"github.com/gocrane/crane/pkg/providers"
+	recommender "github.com/gocrane/crane/pkg/recommendation"
+	"github.com/gocrane/crane/pkg/utils"
+)
+
+// RecommendationTriggerController is responsible for trigger a recommendation
+type RecommendationTriggerController struct {
+	client.Client
+	Recorder        record.EventRecorder
+	RecommenderMgr  recommender.RecommenderManager
+	ScaleClient     scale.ScalesGetter
+	discoveryClient discovery.DiscoveryInterface
+	dynamicClient   dynamic.Interface
+	PredictorMgr    predictormgr.Manager
+	Provider        providers.History
+}
+
+func (c *RecommendationTriggerController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	klog.V(4).Infof("Got Recommendation %s to be triggered", req.NamespacedName)
+
+	recommendation := &analysisv1alpha1.Recommendation{}
+	err := c.Client.Get(ctx, req.NamespacedName, recommendation)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if recommendation.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	recommendationRuleRef := utils.GetRecommendationRuleOwnerReference(recommendation)
+	if recommendationRuleRef == nil {
+		klog.Warningf("cannot found referred recommendation rule %s/%s", recommendation.Namespace, recommendationRuleRef.Name)
+		return ctrl.Result{}, nil
+	}
+
+	recommendationRule := &analysisv1alpha1.RecommendationRule{}
+	err = c.Client.Get(ctx, types.NamespacedName{Name: recommendationRuleRef.Name}, recommendationRule)
+	if err != nil {
+		klog.Warningf("cannot found recommendation rule %s/%s", recommendation.Namespace, recommendationRuleRef.Name)
+		return ctrl.Result{}, nil
+	}
+
+	if recommendation.Spec.TargetRef.Kind == "" {
+		return ctrl.Result{}, fmt.Errorf(" recommendation %s has empty target kind", klog.KObj(recommendation))
+	}
+
+	gvr, err := utils.GetGroupVersionResource(c.discoveryClient, recommendation.Spec.TargetRef.APIVersion, recommendation.Spec.TargetRef.Kind)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("get gvr for recommendation %s failed: %v", klog.KObj(recommendation), err)
+	}
+
+	object, err := c.dynamicClient.Resource(*gvr).Namespace(recommendation.Spec.TargetRef.Namespace).Get(ctx, recommendation.Spec.TargetRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("get target object for recommendation %s failed: %v", klog.KObj(recommendation), err)
+	}
+
+	identities := map[string]ObjectIdentity{}
+	key := objRefKey(recommendation.Spec.TargetRef.Kind, recommendation.Spec.TargetRef.APIVersion, recommendation.Spec.TargetRef.Namespace, recommendation.Spec.TargetRef.Name)
+	identities[key] = ObjectIdentity{
+		Namespace:  object.GetNamespace(),
+		Name:       object.GetName(),
+		Kind:       object.GetKind(),
+		APIVersion: object.GetAPIVersion(),
+		Labels:     object.GetLabels(),
+		Object:     *object,
+	}
+
+	newStatus := recommendationRule.Status.DeepCopy()
+	currentMissionIndex := -1
+	for index, mission := range newStatus.Recommendations {
+		if mission.UID == recommendation.UID {
+			currentMissionIndex = index
+			break
+		}
+	}
+
+	if currentMissionIndex == -1 {
+		klog.Warningf("cannot found recommendation mission %s", recommendationRuleRef.Name)
+		return ctrl.Result{}, nil
+	}
+
+	executeMission(context.TODO(), nil, c.RecommenderMgr, c.Provider, c.PredictorMgr, recommendationRule, identities, &newStatus.Recommendations[currentMissionIndex], recommendation, c.Client, c.ScaleClient, metav1.Now(), newStatus.RunNumber)
+	if newStatus.Recommendations[currentMissionIndex].Message != "Success" {
+		err = c.Client.Delete(context.TODO(), recommendation)
+		if err != nil {
+			klog.Errorf("Failed to delete recommendation %s when checking: %v", klog.KObj(recommendation), err)
+		}
+	}
+
+	updateRecommendationRuleStatus(context.TODO(), c.Client, c.Recorder, recommendationRule, newStatus)
+
+	return ctrl.Result{}, nil
+}
+
+func (c *RecommendationTriggerController) SetupWithManager(mgr ctrl.Manager) error {
+	c.discoveryClient = discovery.NewDiscoveryClientForConfigOrDie(mgr.GetConfig())
+	c.dynamicClient = dynamic.NewForConfigOrDie(mgr.GetConfig())
+
+	controller, err := controller.New("recommendation-trigger-controller", mgr, controller.Options{
+		Reconciler: c})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to Recommendation that runNumber decrease
+	return controller.Watch(&source.Kind{Type: &analysisv1alpha1.Recommendation{}}, &recommendationEventHandler{
+		enqueueHandler: handler.EnqueueRequestForObject{},
+	})
+}
+
+type recommendationEventHandler struct {
+	enqueueHandler handler.EnqueueRequestForObject
+}
+
+func (h *recommendationEventHandler) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+}
+
+func (h *recommendationEventHandler) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+}
+
+func (h *recommendationEventHandler) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	newRecommendation := evt.ObjectNew.(*analysisv1alpha1.Recommendation)
+	oldRecommendation := evt.ObjectOld.(*analysisv1alpha1.Recommendation)
+	klog.V(6).Infof("recommendation %s OnUpdate", klog.KObj(newRecommendation))
+
+	oldRunNumber, _ := utils.GetRunNumber(oldRecommendation)
+	newRunNumber, _ := utils.GetRunNumber(newRecommendation)
+	if oldRunNumber > newRunNumber {
+		// only handle this condition: the new runNumber is lower than old runNumber
+		h.enqueueHandler.Update(evt, q)
+	}
+}
+
+func (h *recommendationEventHandler) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+}

--- a/pkg/known/annotation.go
+++ b/pkg/known/annotation.go
@@ -4,6 +4,7 @@ const (
 	HPARecommendationValueAnnotation      = "analysis.crane.io/hpa-recommendation"
 	ReplicasRecommendationValueAnnotation = "analysis.crane.io/replicas-recommendation"
 	ResourceRecommendationValueAnnotation = "analysis.crane.io/resource-recommendation"
+	RunNumberAnnotation                   = "analysis.crane.io/run-number"
 )
 
 const (

--- a/pkg/utils/recommend.go
+++ b/pkg/utils/recommend.go
@@ -2,11 +2,15 @@ package utils
 
 import (
 	"fmt"
+	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 
 	analysisv1alpha1 "github.com/gocrane/api/analysis/v1alpha1"
+
+	"github.com/gocrane/crane/pkg/known"
 )
 
 func GetGroupVersionResource(discoveryClient discovery.DiscoveryInterface, apiVersion string, kind string) (*schema.GroupVersionResource, error) {
@@ -34,11 +38,37 @@ func GetGroupVersionResource(discoveryClient discovery.DiscoveryInterface, apiVe
 	return &gvr, nil
 }
 
-func IsRecommendationControlledByRule(hpa *analysisv1alpha1.Recommendation) bool {
-	for _, ownerReference := range hpa.OwnerReferences {
+func IsRecommendationControlledByRule(recommend *analysisv1alpha1.Recommendation) bool {
+	for _, ownerReference := range recommend.OwnerReferences {
 		if ownerReference.Kind == "RecommendationRule" {
 			return true
 		}
 	}
 	return false
+}
+
+func SetRunNumber(recommendation *analysisv1alpha1.Recommendation, runNumber int32) {
+	if recommendation.Annotations == nil {
+		recommendation.Annotations = map[string]string{}
+	}
+	recommendation.Annotations[known.RunNumberAnnotation] = strconv.Itoa(int(runNumber))
+}
+
+func GetRunNumber(recommendation *analysisv1alpha1.Recommendation) (int32, error) {
+	val, ok := recommendation.Annotations[known.RunNumberAnnotation]
+	if ok && len(val) != 0 {
+		runNumberInt, err := strconv.ParseInt(val, 10, 32)
+		return int32(runNumberInt), err
+	}
+
+	return 0, fmt.Errorf("get runNumber failed")
+}
+
+func GetRecommendationRuleOwnerReference(recommend *analysisv1alpha1.Recommendation) *metav1.OwnerReference {
+	for _, ownerReference := range recommend.OwnerReferences {
+		if ownerReference.Kind == "RecommendationRule" {
+			return &ownerReference
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

Feature


#### What this PR does / why we need it:

Manually triggering a recommendation can be done through the following steps:

1. Obtain the runNumber from the recommendationRule.
<img width="393" alt="image" src="https://user-images.githubusercontent.com/6251116/223976045-78cc795f-80a9-46f9-9505-4e0e8101c0ac.png">

2. Modify the run number annotation for the recommendation that should be triggered. The run number should be lower than the runNumber in the recommendationRule. For example, if recommendationRule.status.runNumber=6, then change the annotation value to 5.
<img width="626" alt="image" src="https://user-images.githubusercontent.com/6251116/223975856-e40a4dd3-e2fc-4789-954b-032b26665bee.png">

3. The recommendationRule controller checks for updates every 10 seconds. Once it detects the modified run number, it triggers the recommendation flow and updates the recommendationRule.status and recommendation. The recommendation's runNumber is modified to match that of the recommendationRule. You can use this to know when the manual trigger is finished.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

