### PR TITLE
add metric kind for prometheus builder

### DIFF
--- a/pkg/querybuilder-providers/prometheus/builder.go
+++ b/pkg/querybuilder-providers/prometheus/builder.go
@@ -59,12 +59,12 @@ func (b *builder) workloadQuery(metric *metricquery.Metric) (query *metricquery.
 	case v1.ResourceCPU.String():
 		metricRule = prometheus_adapter.MatchMetricRule(mrs.MetricRulesExternal, prometheus_adapter.WorkloadCpuUsageExpression)
 		if metricRule == nil {
-			queryExpr = utils.GetWorkloadCpuUsageExpression(metric.Workload.Namespace, metric.Workload.Name, "")
+			queryExpr = utils.GetWorkloadCpuUsageExpression(metric.Workload.Namespace, metric.Workload.Name, metric.Workload.Kind)
 		}
 	case v1.ResourceMemory.String():
 		metricRule = prometheus_adapter.MatchMetricRule(mrs.MetricRulesExternal, prometheus_adapter.WorkloadMemUsageExpression)
 		if metricRule == nil {
-			queryExpr = utils.GetWorkloadMemUsageExpression(metric.Workload.Namespace, metric.Workload.Name, "")
+			queryExpr = utils.GetWorkloadMemUsageExpression(metric.Workload.Namespace, metric.Workload.Name, metric.Workload.Kind)
 		}
 	default:
 		return nil, fmt.Errorf("metric type %v do not support resource metric %v. only support %v now", metric.Type, metric.MetricName, supportedResources.List())
@@ -118,12 +118,12 @@ func (b *builder) containerQuery(metric *metricquery.Metric) (query *metricquery
 	case v1.ResourceCPU.String():
 		metricRule = prometheus_adapter.MatchMetricRule(mrs.MetricRulesExternal, prometheus_adapter.ContainerCpuUsageExpression)
 		if metricRule == nil {
-			queryExpr = utils.GetContainerCpuUsageExpression(metric.Container.Namespace, metric.Container.WorkloadName, "", metric.Container.Name)
+			queryExpr = utils.GetContainerCpuUsageExpression(metric.Container.Namespace, metric.Container.WorkloadName, metric.Container.WorkloadKind, metric.Container.Name)
 		}
 	case v1.ResourceMemory.String():
 		metricRule = prometheus_adapter.MatchMetricRule(mrs.MetricRulesExternal, prometheus_adapter.ContainerMemUsageExpression)
 		if metricRule == nil {
-			queryExpr = utils.GetContainerMemUsageExpression(metric.Container.Namespace, metric.Container.WorkloadName, "", metric.Container.Name)
+			queryExpr = utils.GetContainerMemUsageExpression(metric.Container.Namespace, metric.Container.WorkloadName, metric.Container.WorkloadKind, metric.Container.Name)
 		}
 	default:
 		return nil, fmt.Errorf("metric type %v do not support resource metric %v. only support %v now", metric.Type, metric.MetricName, supportedResources.List())

--- a/pkg/querybuilder-providers/prometheus/builder_test.go
+++ b/pkg/querybuilder-providers/prometheus/builder_test.go
@@ -46,7 +46,7 @@ func TestBuildQuery(t *testing.T) {
 					APIVersion: "v1",
 				},
 			},
-			want: utils.GetWorkloadCpuUsageExpression("default", "test", ""),
+			want: utils.GetWorkloadCpuUsageExpression("default", "test", "Deployment"),
 		},
 		{
 			desc: "tc2-workload-mem",
@@ -60,7 +60,7 @@ func TestBuildQuery(t *testing.T) {
 					APIVersion: "v1",
 				},
 			},
-			want: utils.GetWorkloadMemUsageExpression("default", "test", ""),
+			want: utils.GetWorkloadMemUsageExpression("default", "test", "Deployment"),
 		},
 		{
 			desc: "tc3-container-cpu",
@@ -70,10 +70,11 @@ func TestBuildQuery(t *testing.T) {
 				Container: &metricquery.ContainerNamerInfo{
 					Namespace:    "default",
 					WorkloadName: "workload",
+					WorkloadKind: "Deployment",
 					Name:         "container",
 				},
 			},
-			want: utils.GetContainerCpuUsageExpression("default", "workload", "", "container"),
+			want: utils.GetContainerCpuUsageExpression("default", "workload", "Deployment", "container"),
 		},
 		{
 			desc: "tc4-container-mem",
@@ -83,10 +84,11 @@ func TestBuildQuery(t *testing.T) {
 				Container: &metricquery.ContainerNamerInfo{
 					Namespace:    "default",
 					WorkloadName: "workload",
+					WorkloadKind: "Deployment",
 					Name:         "container",
 				},
 			},
-			want: utils.GetContainerMemUsageExpression("default", "workload", "", "container"),
+			want: utils.GetContainerMemUsageExpression("default", "workload", "Deployment", "container"),
 		},
 		{
 			desc: "tc5-node-cpu",


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it:
add metric kind for prometheus builder, otherwise in the GetPodNameReg method, the switch will not be entered.

```
func GetPodNameReg(resourceName string, resourceType string) string {
	switch resourceType {
	case "ReplicaSet":
		return fmt.Sprintf("^%s-%s", resourceName, PostRegMatchesPodReplicaset)
	case "Deployment":
		return fmt.Sprintf("^%s-%s", resourceName, PostRegMatchesPodDeployment)
	case "StatefulSet":
		return fmt.Sprintf("^%s-%s", resourceName, PostRegMatchesPodStatefulset)
	}
	return fmt.Sprintf("^%s-%s", resourceName, `.*`)

}
```

#### Special notes for your reviewer:

