### PR TITLE
fix: QueryWindow Range - LAST_1_DAY 前台时间范围不准确 #778

### DIFF
--- a/pkg/web/src/utils/rangeMap.ts
+++ b/pkg/web/src/utils/rangeMap.ts
@@ -3,7 +3,7 @@ import dayjs from 'dayjs';
 import { QueryWindow } from '../models';
 
 export const rangeMap = {
-  [QueryWindow.LAST_1_DAY]: [dayjs().startOf('day'), dayjs()],
+  [QueryWindow.LAST_1_DAY]: [dayjs(+dayjs() - 3600 * 24 * 1000), dayjs()],
   [QueryWindow.LAST_7_DAY]: [dayjs().subtract(7, 'd').startOf('day'), dayjs()],
   [QueryWindow.LAST_30_DAY]: [dayjs().subtract(30, 'd').startOf('day'), dayjs()],
 };


### PR DESCRIPTION
<img width="375" alt="image" src="https://github.com/gocrane/crane/assets/35299017/d5997e0e-cd65-4125-8b6d-3e0d019dbf42">
