### PR TITLE
fix ehpa controller update hpa logic

### DIFF
--- a/pkg/controller/ehpa/hpa.go
+++ b/pkg/controller/ehpa/hpa.go
@@ -173,6 +173,9 @@ func (c *EffectiveHPAController) UpdateHPAIfNeed(ctx context.Context, ehpa *auto
 			updated := &autoscalingv2.HorizontalPodAutoscaler{}
 			errGet := c.Get(context.TODO(), types.NamespacedName{Namespace: hpaCopy.Namespace, Name: hpaCopy.Name}, updated)
 			if errGet == nil {
+                                updated.Labels = hpaCopy.Labels
+				updated.Annotations = hpaCopy.Annotations
+				updated.Spec = hpaCopy.Spec
 				hpaCopy = updated
 			}
 

--- a/pkg/controller/ehpa/hpa.go
+++ b/pkg/controller/ehpa/hpa.go
@@ -173,7 +173,7 @@ func (c *EffectiveHPAController) UpdateHPAIfNeed(ctx context.Context, ehpa *auto
 			updated := &autoscalingv2.HorizontalPodAutoscaler{}
 			errGet := c.Get(context.TODO(), types.NamespacedName{Namespace: hpaCopy.Namespace, Name: hpaCopy.Name}, updated)
 			if errGet == nil {
-                                updated.Labels = hpaCopy.Labels
+				updated.Labels = hpaCopy.Labels
 				updated.Annotations = hpaCopy.Annotations
 				updated.Spec = hpaCopy.Spec
 				hpaCopy = updated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
fix ehpa controller update hpa logic, make sure ehpa controller updates HPA as expected or return update failed error


#### What this PR does / why we need it:
**fix ideas:** If there is a conflict error during the update, reacquire the latest HPA object A2, and then assign the expected update content in A1 to A2
**bug in the current code:** The operator wants to update HPA A1, if the update conflicts, it will directly obtain the latest HPA object A2 from the cluster, and then use A2 to re-initiate the update. And this A2 is not the content A1 that is expected to be updated. At the same time, if A2 update is successful, the exception of update failure will also be lost, resulting in A1 not being updated, but operator thinks that HPA A1 has been updated.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #815

#### Special notes for your reviewer:

