### PR TITLE
fix err logs in crane-agent

### DIFF
--- a/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
+++ b/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
@@ -117,6 +117,11 @@ func (c *CadvisorCollector) Collect() (map[string][]common.TimeSeries, error) {
 
 	var stateMap = make(map[string][]common.TimeSeries)
 	for _, pod := range allPods {
+
+		if utils.IsStaticPod(pod) {
+			continue
+		}
+
 		var now = time.Now()
 		containers, err := c.Manager.GetContainerInfoV2(utils.GetCgroupPath(pod, c.Manager.GetCgroupDriver()), cadvisorapiv2.RequestOptions{
 			IdType:    cadvisorapiv2.TypeName,

--- a/pkg/utils/pod.go
+++ b/pkg/utils/pod.go
@@ -376,3 +376,9 @@ func GetPodOwnerReference(ctx context.Context, kubeClient client.Client, pod *v1
 func IsPodTerminated(pod *corev1.Pod) bool {
 	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
 }
+
+func IsStaticPod(pod *corev1.Pod) bool {
+	_, isStatic := pod.Annotations[kubelettypes.ConfigSourceAnnotationKey]
+
+	return isStatic
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### Special notes for your reviewer:

Static pods in Kubernetes are not managed by cgroups in /sys/fs/cgroup/, which means cadvisor can not get containerinfo by it.
<img width="1462" alt="image" src="https://github.com/gocrane/crane/assets/17697155/be3e57b4-99a5-4ab8-a0bd-bee110ac6673">
The error logs are continuously being output in the crane-agent.