### PR TITLE
fix config fetcher flush the rules

### DIFF
--- a/pkg/prometheus-adapter/config_fetcher.go
+++ b/pkg/prometheus-adapter/config_fetcher.go
@@ -129,20 +129,3 @@ func (pc *PrometheusAdapterConfigFetcher) Reload() {
 		}
 	}
 }
-
-func FlushRules(metricsDiscoveryConfig config.MetricsDiscoveryConfig, mapper meta.RESTMapper) error {
-	err := ParsingResourceRules(metricsDiscoveryConfig, mapper)
-	if err != nil {
-		return err
-	}
-	err = ParsingRules(metricsDiscoveryConfig, mapper)
-	if err != nil {
-		return err
-	}
-	err = ParsingExternalRules(metricsDiscoveryConfig, mapper)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?

fix  config fetcher flush the rules when prometheus-adapter-config only configure rules and externalRules

#### What this PR does / why we need it:

1. Crane will not crash if only ResourceRules are configured and others are not.
2. Decouple the refresh of ResourceRules, CustomerRules, and ExternalRules, so that if one of them has a problem, it will not affect the others.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #829 

#### Special notes for your reviewer:

