### PR TITLE
Fix crane agent panic when handling ext memory pods.

### DIFF
--- a/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
+++ b/pkg/ensurance/collector/cadvisor/cadvisor_linux.go
@@ -163,7 +163,7 @@ func (c *CadvisorCollector) Collect() (map[string][]common.TimeSeries, error) {
 				continue
 			}
 
-			if hasExtMemRes {
+			if hasExtMemRes && v.Stats[0].Memory != nil {
 				extResMemUse += float64(v.Stats[0].Memory.WorkingSet)
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
bugfix

#### What this PR does / why we need it:
Crane agent will panic if we use ext memory. Fix it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #889

#### Special notes for your reviewer:

