### PR TITLE
hpa recommender fluctuation-threshold 默认值不生效

### DIFF
--- a/pkg/recommendation/recommender/hpa/recommend.go
+++ b/pkg/recommendation/recommender/hpa/recommend.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
-	"strconv"
 	"time"
 
 	"github.com/montanaflynn/stats"
@@ -241,18 +240,13 @@ func (rr *HPARecommender) minMaxMedians(predictionTs []*common.TimeSeries) (floa
 
 // checkFluctuation check if the time series fluctuation is reach to replicas.fluctuation-threshold
 func (rr *HPARecommender) checkFluctuation(medianMin, medianMax float64) error {
-	fluctuationThreshold, err := strconv.ParseFloat(rr.Config["fluctuation-threshold"], 64)
-	if err != nil {
-		return err
-	}
-
 	if medianMin == 0 {
 		medianMin = 0.1 // use a small value to continue calculate
 	}
 
 	fluctuation := medianMax / medianMin
-	if fluctuation < fluctuationThreshold {
-		return fmt.Errorf("target cpu fluctuation %f is under replicas.fluctuation-threshold %f. ", fluctuation, fluctuationThreshold)
+	if fluctuation < rr.FluctuationThreshold {
+		return fmt.Errorf("target cpu fluctuation %f is under replicas.fluctuation-threshold %f. ", fluctuation, rr.FluctuationThreshold)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

-->

#### What type of PR is this?
bug fix

#### What this PR does / why we need it:
修复 hpa recommender 未在配置中指定 fluctuation-threshold 时，创建 recommend 失败的问题。

通过 RecommendationRule 创建 HPA 的 recommend 时，报错如下：
E0228 11:30:47.033358   73667 manager.go:180] RecommendationRule(workloads-rule-test) Target(default/xxxxxxxxxx): recommender "HPA" failed at recommend policy phase: HPA checkFluctuation failed: strconv.ParseFloat: parsing "": invalid syntax

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:

